### PR TITLE
Fixed creation of mixed mode STR

### DIFF
--- a/src/iso.cpp
+++ b/src/iso.cpp
@@ -40,9 +40,9 @@ int iso::DirTreeClass::GetWavSize(const char* wavFile)
 
 	fread( &HeaderChunk, 1, sizeof(HeaderChunk), fp );
 
-	if ( memcmp( &HeaderChunk.id, "RIFF", 4 ) || 
+	if ( memcmp( &HeaderChunk.id, "RIFF", 4 ) ||
 		memcmp( &HeaderChunk.format, "WAVE", 4 ) )
-	{	
+	{
 		// It must be a raw
 		fseek(fp, 0, SEEK_END);
 		int wavlen = ftell(fp);
@@ -73,7 +73,7 @@ int iso::DirTreeClass::GetWavSize(const char* wavFile)
 		fclose( fp );
 		return 0;
 	}
-	
+
 	// Search for the data chunk
 	struct
 	{
@@ -94,9 +94,9 @@ int iso::DirTreeClass::GetWavSize(const char* wavFile)
 			break;
 		}
 	}
-	
+
 	fclose( fp );
-	
+
 	return 2352*((WAV_Subchunk2.len+2351)/2352);
 }
 
@@ -105,7 +105,7 @@ int iso::DirTreeClass::PackWaveFile(cd::IsoWriter* writer, const char* wavFile, 
 	FILE *fp;
 	int waveLen;
 	unsigned char buff[CD_SECTOR_SIZE];
-	
+
 	if ( !( fp = fopen( wavFile, "rb" ) ) )
 	{
 		printf("ERROR: File not found.\n");
@@ -122,27 +122,27 @@ int iso::DirTreeClass::PackWaveFile(cd::IsoWriter* writer, const char* wavFile, 
 
 	fread( &HeaderChunk, 1, sizeof(HeaderChunk), fp );
 
-	if ( memcmp( &HeaderChunk.id, "RIFF", 4 ) || 
+	if ( memcmp( &HeaderChunk.id, "RIFF", 4 ) ||
 		memcmp( &HeaderChunk.format, "WAVE", 4 ) )
 	{
-		
+
 		// File must be a raw, pack it anyway
 		memset(buff, 0x00, CD_SECTOR_SIZE);
-		
+
 		if ( pregap ) {
-			
+
 			// Write pregap region
 			for ( int i=0; i<150; i++ ) {
 				writer->WriteBytesRaw(buff, CD_SECTOR_SIZE);
 			}
-			
+
 		}
 
 		// Write data
 		fseek(fp, 0, SEEK_END);
 		waveLen = ftell(fp);
 		fseek(fp, 0, SEEK_SET);
-		
+
 		while ( waveLen > 0 )
 		{
 			memset(buff, 0x00, CD_SECTOR_SIZE);
@@ -161,7 +161,7 @@ int iso::DirTreeClass::PackWaveFile(cd::IsoWriter* writer, const char* wavFile, 
 		}
 
 		printf("Packed as raw... ");
-		
+
 		fclose( fp );
 		return true;
 	}
@@ -188,7 +188,7 @@ int iso::DirTreeClass::PackWaveFile(cd::IsoWriter* writer, const char* wavFile, 
 		{
 			printf( "\n    " );
 		}
-		
+
 		printf( "ERROR: Unsupported WAV format.\n" );
 
 		fclose( fp );
@@ -196,14 +196,14 @@ int iso::DirTreeClass::PackWaveFile(cd::IsoWriter* writer, const char* wavFile, 
 	}
 
 
-    if ( (WAV_Subchunk1.chan != 2) || (WAV_Subchunk1.freq != 44100) || 
+    if ( (WAV_Subchunk1.chan != 2) || (WAV_Subchunk1.freq != 44100) ||
 		(WAV_Subchunk1.bps != 16) )
 	{
 		if ( !global::QuietMode )
 		{
 			printf( "\n    " );
 		}
-		
+
 		printf( "ERROR: Only 44.1KHz, 16-bit Stereo WAV files are supported.\n" );
 
 		fclose( fp );
@@ -232,7 +232,7 @@ int iso::DirTreeClass::PackWaveFile(cd::IsoWriter* writer, const char* wavFile, 
 	}
 
 	waveLen = WAV_Subchunk2.len;
-	
+
 	// Write pregap region
 	memset(buff, 0x00, CD_SECTOR_SIZE);
 	if ( pregap )
@@ -242,7 +242,7 @@ int iso::DirTreeClass::PackWaveFile(cd::IsoWriter* writer, const char* wavFile, 
 			writer->WriteBytesRaw(buff, CD_SECTOR_SIZE);
 		}
 	}
-	
+
 	// Write data
 	while ( waveLen > 0 )
 	{
@@ -254,7 +254,7 @@ int iso::DirTreeClass::PackWaveFile(cd::IsoWriter* writer, const char* wavFile, 
 		{
 			readLen = CD_SECTOR_SIZE;
 		}
-		
+
 		fread( buff, 1, readLen, fp );
         writer->WriteBytesRaw( buff, CD_SECTOR_SIZE );
 
@@ -271,7 +271,7 @@ iso::DirTreeClass::DirTreeClass()
 	passedSector = false;
 	parent = nullptr;
 	first_track = false;
-	
+
 	name = rootname;
 }
 
@@ -296,7 +296,7 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 		{
 			printf("      ");
 		}
-		
+
 		printf("ERROR: File not found: %s\n", srcfile);
 		return false;
     }
@@ -309,7 +309,7 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 		FILE* fp = fopen(srcfile, "rb");
 		fread(buff, 1, 4, fp);
 		fclose(fp);
-		
+
 		// Check if its a RIFF (WAV container)
 		if ( strncmp(buff, "RIFF", 4) == 0 )
 		{
@@ -319,10 +319,10 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 			}
 
 			printf("ERROR: %s is a WAV or is not properly ripped!\n", srcfile);
-			
+
 			return false;
 		}
-		
+
 		// Check if size is a multiple of 2336 bytes
 		if ( ( fileAttrib.st_size % 2336 ) != 0 )
 		{
@@ -339,11 +339,11 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 			}
 
 			printf("Did you create your multichannel XA file with subheader data?\n");
-			
+
 			return false;
 		}
-		
-		// Check if first sub header is valid usually by checking 
+
+		// Check if first sub header is valid usually by checking
 		// if the first four bytes match the next four bytes
 		else if ( ((int*)buff)[0] == ((int*)buff)[1] )
 		{
@@ -354,16 +354,16 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 
 			printf("WARNING: %s may not have a valid subheader. ", srcfile);
 		}
-	
+
 	// Check STR data
 	} else if ( type == EntrySTR ) {
-		
+
 		// Check header
 		char buff[4];
 		FILE* fp = fopen(srcfile, "rb");
 		fread(buff, 1, 4, fp);
 		fclose(fp);
-		
+
 		// Check if its a RIFF (WAV container)
 		if ( strncmp(buff, "RIFF", 4) == 0 )
 		{
@@ -373,10 +373,10 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 			}
 
 			printf("ERROR: %s is a WAV or is not properly ripped.\n", srcfile);
-			
+
 			return false;
 		}
-		
+
 		// Check if size is a multiple of 2336 bytes
 		if ( ( fileAttrib.st_size % 2336 ) != 0 )
 		{
@@ -384,20 +384,20 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 			{
 				type = EntrySTR_DO;
 			}
-			else 
+			else
 			{
 				if ( !global::QuietMode )
 				{
 					printf("      ");
 				}
 
-				printf("ERROR: %s is not a multiple of 2336 or 2048 bytes.\n", 
+				printf("ERROR: %s is not a multiple of 2336 or 2048 bytes.\n",
 					srcfile);
-				
+
 				return false;
 			}
 		}
-		
+
 	}
 
 
@@ -407,7 +407,7 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 	{
 		temp_name[i] = std::toupper( temp_name[i] );
 	}
-	
+
 	temp_name += ";1";
 
 
@@ -416,14 +416,14 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 	{
 		if ( !entries[i].id.empty() )
 		{
-            if ( ( entries[i].type == EntryFile ) 
+            if ( ( entries[i].type == EntryFile )
 				&& ( icompare( entries[i].id, temp_name ) ) )
 			{
 				if (!global::QuietMode)
 				{
 					printf("      ");
 				}
-				
+
 				printf("ERROR: Duplicate file entry: %s\n", id);
 
 				return false;
@@ -432,10 +432,10 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 		}
 
     }
-	
+
 	DIRENTRY entry;
 	memset( &entry, 0x00, sizeof(DIRENTRY) );
-	
+
 	entry.id.assign(temp_name.c_str());
 	entry.type		= type;
 	entry.subdir	= nullptr;
@@ -444,7 +444,7 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 	{
 		entry.srcfile = srcfile;
 	}
-	
+
 	if ( type == EntryDA )
 	{
 		entry.length = GetWavSize( srcfile );
@@ -452,8 +452,8 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 	else if ( type != EntryDir )
 	{
 		entry.length = fileAttrib.st_size;
-	} 
-	
+	}
+
     tm* fileTime = gmtime( &fileAttrib.st_mtime );
 
     entry.date.hour		= fileTime->tm_hour;
@@ -473,7 +473,7 @@ int	iso::DirTreeClass::AddFileEntry(const char* id, int type, const char* srcfil
 void iso::DirTreeClass::AddDummyEntry(int sectors)
 {
 	DIRENTRY entry;
-	
+
 	entry.subdir	= nullptr;
 	entry.type		= EntryFile;
 	entry.length	= 2048*sectors;
@@ -487,14 +487,14 @@ iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(const char* id)
 	{
 		if ( !entries[i].id.empty() )
 		{
-			if ( ( entries[i].type == iso::EntryDir ) && 
+			if ( ( entries[i].type == iso::EntryDir ) &&
 				( entries[i].id.compare( id ) == 0 ) )
 			{
 				if (!global::QuietMode)
 				{
 					printf("      ");
 				}
-				
+
 				printf("ERROR: Duplicate directory entry: %s\n", id);
 
 				return nullptr;
@@ -504,21 +504,21 @@ iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(const char* id)
     }
 
 	DIRENTRY entry;
-	
+
 	entry.id		= id;
-	
+
 	for ( int i=0; i<entry.id.size(); i++ )
 	{
 		entry.id[i] = std::toupper( entry.id[i] );
 	}
-	
+
 	entry.type		= EntryDir;
 	entry.subdir	= (void*) new DirTreeClass;
-	
+
 	entries.push_back( entry );
-	
+
 	entries.back().length	= ((iso::DirTreeClass*)entries.back().subdir)->CalculateDirEntryLen();
-	
+
 	((DirTreeClass*)entry.subdir)->parent = this;
 
 	tm*	dirTime = gmtime( &global::BuildTime );
@@ -547,13 +547,13 @@ void iso::DirTreeClass::PrintRecordPath()
 	{
 		return;
 	}
-	
+
 	p->PrintRecordPath();
 	printf( "/%s", name.c_str() );
 }
 
 int iso::DirTreeClass::CalculateFileSystemSize(int lba) {
-	
+
 	// Set LBA of directory record of this class
 	recordLBA = lba;
 
@@ -570,12 +570,12 @@ int iso::DirTreeClass::CalculateFileSystemSize(int lba) {
 		else
 		{
 			// Increment LBA by the size of files
-			if ( ( entries[i].type == EntryFile ) || 
+			if ( ( entries[i].type == EntryFile ) ||
 				( entries[i].type == EntrySTR_DO ) )
 			{
 				lba += (entries[i].length+2047)/2048;
 			}
-			else if ( ( entries[i].type == EntryXA ) || 
+			else if ( ( entries[i].type == EntryXA ) ||
 				( entries[i].type == EntrySTR ) )
 			{
 				lba += (entries[i].length+2335)/2336;
@@ -584,7 +584,7 @@ int iso::DirTreeClass::CalculateFileSystemSize(int lba) {
 	}
 
 	return lba;
-	
+
 }
 
 int iso::DirTreeClass::CalculateTreeLBA(int lba)
@@ -615,7 +615,7 @@ int iso::DirTreeClass::CalculateTreeLBA(int lba)
 		{
 			entries[i].lba = lba;
 		}
-		
+
 		// If it is a subdir
 		if (entries[i].subdir != nullptr)
 		{
@@ -629,12 +629,12 @@ int iso::DirTreeClass::CalculateTreeLBA(int lba)
 		else
 		{
 			// Increment LBA by the size of file
-			if ( ( entries[i].type == EntryFile ) || 
+			if ( ( entries[i].type == EntryFile ) ||
 				( entries[i].type == EntrySTR_DO ) )
 			{
 				lba += (entries[i].length+2047)/2048;
 			}
-			else if ( ( entries[i].type == EntryXA ) || 
+			else if ( ( entries[i].type == EntryXA ) ||
 				(entries[i].type == EntrySTR ) )
 			{
 				lba += (entries[i].length+2335)/2336;
@@ -666,14 +666,14 @@ int iso::DirTreeClass::CalculateDirEntryLen()
 	{
 		dirEntryLen += 28;
 	}
-	
+
 	for ( int i=0; i<entries.size(); i++ )
 	{
 		if ( entries[i].id.empty() )
 		{
 			continue;
 		}
-		
+
 		int dataLen = 33;
 
 		dataLen += 2*((entries[i].id.size()+1)/2);
@@ -682,12 +682,12 @@ int iso::DirTreeClass::CalculateDirEntryLen()
 		{
 			dataLen++;
 		}
-		
+
 		if ( !global::noXA )
 		{
 			dataLen += sizeof( cd::ISO_XA_ATTRIB );
 		}
-		
+
 		if ( ((dirEntryLen%2048)+dataLen) > 2048 )
 		{
 			dirEntryLen = (2048*(dirEntryLen/2048))+(dirEntryLen%2048);
@@ -700,7 +700,7 @@ int iso::DirTreeClass::CalculateDirEntryLen()
 	{
 		passedSector = true;
 	}
-	
+
 	return 2048*((dirEntryLen+2047)/2048);
 }
 
@@ -713,7 +713,7 @@ void iso::DirTreeClass::SortDirEntries()
 	{
 		return;
 	}
-	
+
 	// Search for directories
 	for(int i=0; i<entries.size(); i++)
 	{
@@ -761,7 +761,7 @@ void iso::DirTreeClass::SortDirEntries()
 			}
 		}
 	}
-	
+
 }
 
 int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
@@ -770,7 +770,7 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 	char*	dataBuffPtr=dataBuff;
 	char	entryBuff[128];
 	int		dirlen;
-	
+
 	cd::ISO_DIR_ENTRY*	entry;
 	cd::ISO_XA_ATTRIB*	xa;
 
@@ -791,7 +791,7 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 		{
 			// Current
 			dirlen = 2048*((CalculateDirEntryLen()+2047)/2048);
-			
+
 			SetPair32( &entry->entrySize, dirlen );
 			SetPair32( &entry->entryOffs, recordLBA );
 		}
@@ -804,7 +804,7 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 				dirlen = CalculateDirEntryLen();
 			}
 			dirlen = 2048*((dirlen+2047)/2048);
-			
+
 			SetPair32( &entry->entrySize, dirlen );
 			SetPair32( &entry->entryOffs, lastLBA );
 			dataBuffPtr[dataLen+1] = 0x01;
@@ -823,7 +823,7 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 
 			dataLen += sizeof(cd::ISO_XA_ATTRIB);
 		}
-		
+
 		entry->flags = 0x02;
 		entry->entryLength = dataLen;
 
@@ -845,7 +845,7 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 		{
 			continue;
 		}
-		
+
 		memset( entryBuff, 0x00, 128 );
 		entry = (cd::ISO_DIR_ENTRY*)entryBuff;
 
@@ -861,7 +861,7 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 		// File length correction for certain file types
 		int lba = entries[i].lba;
 		int length = 0;
-		
+
 		if ( ( entries[i].type == EntryXA ) || ( entries[i].type == EntrySTR ) )
 		{
 			length = 2048*((entries[i].length+2335)/2336);
@@ -879,14 +879,14 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 		{
 			length = entries[i].length;
 		}
-		
+
 		SetPair32( &entry->entryOffs, lba );
 		SetPair32( &entry->entrySize, length );
 		SetPair16( &entry->volSeqNum, 1 );
 
 		entry->identifierLen = entries[i].id.length();
 		entry->entryDate = entries[i].date;
-		
+
 		int dataLen = 33;
 
 		strncpy( &entryBuff[dataLen], entries[i].id.c_str(), entry->identifierLen );
@@ -896,7 +896,7 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 		{
 			dataLen++;
 		}
-		
+
 		if ( !global::noXA )
 		{
 			xa = (cd::ISO_XA_ATTRIB*)(entryBuff+dataLen);
@@ -905,7 +905,7 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 			xa->id[0] = 'X';
 			xa->id[1] = 'A';
 
-			if ( (entries[i].type == EntryFile) || 
+			if ( (entries[i].type == EntryFile) ||
 				(entries[i].type == EntrySTR_DO) )
 			{
 				xa->attributes	= 0x550d;
@@ -914,7 +914,7 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 			{
 				xa->attributes	= 0x5545;
 			}
-			else if ( (entries[i].type == EntrySTR) || 
+			else if ( (entries[i].type == EntrySTR) ||
 				(entries[i].type == EntryXA) )
 			{
 				xa->attributes	= 0x553d;
@@ -926,7 +926,7 @@ int iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, int lastLBA)
 
 			dataLen += sizeof(cd::ISO_XA_ATTRIB);
 		}
-		
+
 		entry->entryLength = dataLen;
 
 		if ( (dataBuffPtr+dataLen) > (dataBuff+2047) )
@@ -954,14 +954,14 @@ int iso::DirTreeClass::WriteDirectoryRecords(cd::IsoWriter* writer, int lastDirL
 	{
 		lastDirLBA = recordLBA;
 	}
-	
+
 	WriteDirEntries( writer, lastDirLBA );
 
 	for ( int i=0; i<entries.size(); i++ )
 	{
 		if ( entries[i].type == EntryDir )
 		{
-			if ( !((DirTreeClass*)entries[i].subdir)->WriteDirectoryRecords( 
+			if ( !((DirTreeClass*)entries[i].subdir)->WriteDirectoryRecords(
 				writer, recordLBA ) )
 			{
 				return 0;
@@ -975,7 +975,7 @@ int iso::DirTreeClass::WriteDirectoryRecords(cd::IsoWriter* writer, int lastDirL
 int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 {
 	first_track = false;
-	
+
 	for ( int i=0; i<entries.size(); i++ )
 	{
 		if ( ( entries[i].type == EntryDA ) && ( first_track ) )
@@ -998,21 +998,21 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 				{
 					printf( "      Packing %s... ", entries[i].srcfile.c_str() );
 				}
-				
+
 				FILE *fp = fopen( entries[i].srcfile.c_str(), "rb" );
 
 				writer->SetSubheader( cd::IsoWriter::SubData );
-				
+
 				while( !feof( fp ) )
 				{
 					memset( buff, 0x00, 2048 );
 					fread( buff, 1, 2048, fp );
-					
+
 					if ( feof( fp ) )
 					{
 						writer->SetSubheader( cd::IsoWriter::SubEOF );
 					}
-					
+
 					writer->WriteBytes( buff, 2048, cd::IsoWriter::EdcEccForm1 );
 				}
 
@@ -1022,7 +1022,7 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 				{
 					printf("Done.\n");
 				}
-				
+
 			}
 			else
 			{
@@ -1049,7 +1049,7 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 			{
 				printf( "      Packing XA %s... ", entries[i].srcfile.c_str() );
 			}
-			
+
 			FILE *fp = fopen( entries[i].srcfile.c_str(), "rb" );
 
 			while( !feof( fp ) )
@@ -1064,7 +1064,7 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 			{
 				printf( "Done.\n" );
 			}
-			
+
 		// Write STR video streams as Mode 2 Form 1 (video sectors) and Mode 2 Form 2 (XA audio sectors)
 		// Video sectors have EDC/ECC while XA does not
 		}
@@ -1076,7 +1076,7 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 			{
 				printf( "      Packing STR %s... ", entries[i].srcfile.c_str() );
 			}
-			
+
 			FILE *fp = fopen( entries[i].srcfile.c_str(), "rb" );
 
 			while ( !feof( fp ) )
@@ -1084,16 +1084,17 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 				memset( buff, 0x00, 2336 );
 				fread( buff, 1, 2336, fp );
 
-				// Check submode if sector is a data sector (bit 3)
-				if ( buff[2]&0x8 )
+				// Check submode if sector is mode 2 form 2
+				if ( buff[2]&0x20 )
 				{
-					// If so, write it as Mode 2 Form 1
-					writer->WriteBytesXA( buff, 2336, cd::IsoWriter::EdcEccForm1 );
+				    // If so, write it as an XA sector
+					writer->WriteBytesXA( buff, 2336, cd::IsoWriter::EdcEccForm2 );
+
 				}
 				else
 				{
-					// Otherwise, write it as an XA sector
-					writer->WriteBytesXA( buff, 2336, cd::IsoWriter::EdcEccNone );
+					// Otherwise, write it as Mode 2 Form 1
+					writer->WriteBytesXA( buff, 2336, cd::IsoWriter::EdcEccForm1 );
 				}
 
 			}
@@ -1104,7 +1105,7 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 			{
 				printf( "Done.\n" );
 			}
-			
+
 		// Write data only STR streams as Mode 2 Form 1
 		}
 		else if ( entries[i].type == EntrySTR_DO )
@@ -1117,28 +1118,28 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 				{
 					printf( "      Packing STR-DO %s... ", entries[i].srcfile.c_str() );
 				}
-				
+
 				FILE *fp = fopen( entries[i].srcfile.c_str(), "rb" );
 
 				writer->SetSubheader( cd::IsoWriter::SubSTR );
-				
+
 				while( !feof( fp ) )
 				{
 					memset( buff, 0x00, 2048 );
 					fread( buff, 1, 2048, fp );
-					
+
 					writer->WriteBytes( buff, 2048, cd::IsoWriter::EdcEccForm1 );
 				}
 
 				fclose( fp );
-				
+
 				writer->SetSubheader(0x00080000);
 
 				if ( !global::QuietMode )
 				{
 					printf("Done.\n");
 				}
-				
+
 			}
 			else
 			{
@@ -1154,7 +1155,7 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 					writer->WriteBytes( buff, 2048, cd::IsoWriter::EdcEccForm1 );
 				}
 			}
-			
+
 		// Write DA files as audio tracks
 		}
 		else if ( entries[i].type == EntryDA )
@@ -1163,7 +1164,7 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 			{
 				printf( "      Packing DA %s... ", entries[i].srcfile.c_str() );
 			}
-			
+
 			if ( PackWaveFile( writer, entries[i].srcfile.c_str(), first_track ) )
 			{
 				if (!global::QuietMode)
@@ -1171,7 +1172,7 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 					printf( "Done.\n" );
 				}
 			}
-			
+
 			first_track = true;
 		}
 		else if ( entries[i].type == EntryDir )
@@ -1209,7 +1210,7 @@ void iso::DirTreeClass::OutputHeaderListing(FILE* fp, int level)
 				{
 					temp_name[c] = '_';
 				}
-				
+
 				if ( temp_name[c] == ';' )
 				{
 					temp_name[c] = 0x00;
@@ -1218,7 +1219,7 @@ void iso::DirTreeClass::OutputHeaderListing(FILE* fp, int level)
 
 			fprintf( fp, "#define %s", temp_name.c_str() );
 
-			for( int s=0; s<17-(int)entries[i].id.size(); s++ )	
+			for( int s=0; s<17-(int)entries[i].id.size(); s++ )
 			{
 				fprintf( fp, " " );
 			}
@@ -1227,7 +1228,7 @@ void iso::DirTreeClass::OutputHeaderListing(FILE* fp, int level)
 
 		}
 	}
-	
+
 	for ( int i=0; i<entries.size(); i++ )
 	{
 		if ( entries[i].type == EntryDir )
@@ -1245,7 +1246,7 @@ void iso::DirTreeClass::OutputHeaderListing(FILE* fp, int level)
 
 int iso::DirTreeClass::WriteCueEntries(FILE* fp, int* trackNum)
 {
-	
+
 	for(int i=0; i<entries.size(); i++)
 	{
 		if ( entries[i].type == EntryDA )
@@ -1271,14 +1272,14 @@ int iso::DirTreeClass::WriteCueEntries(FILE* fp, int* trackNum)
 			fprintf( fp, "    INDEX 01 %02d:%02d:%02d\n",
 				(trackLBA/75)/60, (trackLBA/75)%60, trackLBA%75 );
 
-		} 
+		}
 		else if ( entries[i].type == EntryDir )
 		{
 			((DirTreeClass*)entries[i].subdir)->WriteCueEntries( fp, trackNum );
 		}
-		
+
 	}
-	
+
 	return *trackNum;
 }
 
@@ -1305,7 +1306,7 @@ void iso::DirTreeClass::OutputLBAlisting(FILE* fp, int level)
 			{
 				fprintf( fp, "Dir   " );
 			}
-			else if ( ( entries[i].type == EntrySTR ) || 
+			else if ( ( entries[i].type == EntrySTR ) ||
 				( entries[i].type == EntrySTR_DO ) )
 			{
 				fprintf( fp, "STR   " );
@@ -1337,7 +1338,7 @@ void iso::DirTreeClass::OutputLBAlisting(FILE* fp, int level)
 		{
 			fprintf( fp, " " );
 		}
-		
+
 		// Write LBA offset
 		sprintf( textbuff, "%d", entries[i].lba );
 		fprintf( fp, "%s", textbuff );
@@ -1345,7 +1346,7 @@ void iso::DirTreeClass::OutputLBAlisting(FILE* fp, int level)
 		{
 			fprintf( fp, " " );
 		}
-		
+
 		// Write Timecode
 		LBAtoTimecode( 150+entries[i].lba, textbuff );
 		fprintf( fp, "%s    ", textbuff );
@@ -1357,7 +1358,7 @@ void iso::DirTreeClass::OutputLBAlisting(FILE* fp, int level)
 		{
 			fprintf( fp, " " );
 		}
-		
+
 		// Write source file path
 		if ( (!entries[i].id.empty()) && (entries[i].type != EntryDir) )
 		{
@@ -1367,13 +1368,13 @@ void iso::DirTreeClass::OutputLBAlisting(FILE* fp, int level)
 		{
 			fprintf( fp, " \n" );
 		}
-		
+
 		if ( entries[i].type == EntryDir )
 		{
 			((DirTreeClass*)entries[i].subdir)->OutputLBAlisting( fp, level+1 );
 		}
 	}
-	
+
 	if ( level > 0 )
 	{
 		fprintf( fp, "    End   %s\n", name.c_str() );
@@ -1415,12 +1416,12 @@ int iso::DirTreeClass::CalculatePathTableLen()
 	return len;
 }
 
-void iso::DirTreeClass::GenPathTableSub(PathTableClass* table, 
-	DirTreeClass* dir, int parentIndex, int msb) 
+void iso::DirTreeClass::GenPathTableSub(PathTableClass* table,
+	DirTreeClass* dir, int parentIndex, int msb)
 {
 	for ( int i=0; i<dir->entries.size(); i++ )
 	{
-		if ( dir->entries[i].type == EntryDir ) 
+		if ( dir->entries[i].type == EntryDir )
 		{
 			PathEntryClass* entry = new PathEntryClass;
 
@@ -1434,52 +1435,52 @@ void iso::DirTreeClass::GenPathTableSub(PathTableClass* table,
 			table->entries.push_back( entry );
 		}
 	}
-	
+
 	for ( int i=0; i<table->entries.size(); i++ ) {
-		
+
 		DirTreeClass* subdir = (DirTreeClass*)table->entries[i]->dir;
 		PathTableClass* sub = new PathTableClass;
-		
+
 		GenPathTableSub( sub, subdir, table->entries[i]->next_parent, msb );
 		table->entries[i]->sub = sub;
-		
+
 	}
 }
 
 int iso::DirTreeClass::GeneratePathTable(unsigned char* buff, int msb)
 {
 	PathTableClass pathTable;
-	
+
 	dirIndex = 1;
-	
+
 	for ( int i=0; i<entries.size(); i++ )
 	{
 		if ( entries[i].type == EntryDir )
 		{
 			PathEntryClass* entry = new PathEntryClass;
-			
+
 			dirIndex++;
 			entry->dir_id		= &entries[i].id;
 			entry->dir_level	= 1;
 			entry->dir_lba		= ((DirTreeClass*)entries[i].subdir)->recordLBA;
 			entry->dir			= entries[i].subdir;
 			entry->next_parent	= dirIndex;
-			
+
 			pathTable.entries.push_back(entry);
-			
+
 		}
 	}
-	
+
 	for ( int i=0; i<pathTable.entries.size(); i++ ) {
-		
+
 		DirTreeClass* subdir = (DirTreeClass*)pathTable.entries[i]->dir;
 		PathTableClass* sub = new PathTableClass;
-		
+
 		GenPathTableSub( sub, subdir, pathTable.entries[i]->next_parent, msb );
 		pathTable.entries[i]->sub = sub;
-		
+
 	}
-	
+
 	*buff = 1;	// Directory identifier length
 	buff++;
 	*buff = 0;	// Extended attribute record length (unused)
@@ -1490,7 +1491,7 @@ int iso::DirTreeClass::GeneratePathTable(unsigned char* buff, int msb)
 	// Write LBA and directory number index
 	memcpy( buff, &lba, 4 );
 	*((short*)(buff+4)) = 1;
-	
+
 	if ( msb )
 	{
 		cd::SwapBytes( buff, 4 );
@@ -1502,11 +1503,11 @@ int iso::DirTreeClass::GeneratePathTable(unsigned char* buff, int msb)
 	// Put identifier (nullptr if first entry)
 	memset( buff, 0x00, 2 );
 	buff += 2;
-	
+
 	unsigned char* newbuff = pathTable.GenTableData( buff, msb );
-	
+
 	return (int)(newbuff-buff);
-	
+
 }
 
 int iso::DirTreeClass::GetFileCountTotal()
@@ -1551,18 +1552,18 @@ void iso::WriteLicenseData(cd::IsoWriter* writer, void* data)
 {
 	writer->SeekToSector( 0 );
 	writer->WriteBytesXA( data, 2336*12, cd::IsoWriter::EdcEccForm1 );
-	
+
 	char blank[2048];
 	memset(blank, 0, 2048);
-	
+
 	writer->SetSubheader(0x00200000);
-	
+
 	for( int i=0; i<4; i++ ) {
-		
+
 		writer->WriteBytes( data, 2048, cd::IsoWriter::EdcEccForm1 );
-		
+
 	}
-	
+
 	writer->SetSubheader(0x00080000);
 }
 
@@ -1579,7 +1580,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 
 	// Set System identifier
 	memset( isoDescriptor.systemID, 0x20, 32 );
-	
+
 	if ( id.SystemID != nullptr )
 	{
 		for ( int i=0; i<(int)strlen(id.SystemID); i++ )
@@ -1590,7 +1591,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 
 	// Set Volume identifier
 	memset( isoDescriptor.volumeID, 0x20, 32 );
-	
+
 	if ( id.VolumeID != nullptr )
 	{
 		for ( int i=0; i<(int)strlen(id.VolumeID); i++ )
@@ -1601,12 +1602,12 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 
 	// Set Application identifier
 	memset( isoDescriptor.applicationIdentifier, 0x20, 128 );
-	
+
 	if ( id.Application != nullptr )
 	{
 		for ( int i=0; i<(int)strlen(id.Application); i++ )
 		{
-			isoDescriptor.applicationIdentifier[i] = 
+			isoDescriptor.applicationIdentifier[i] =
 				std::toupper( id.Application[i] );
 		}
 	}
@@ -1617,7 +1618,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 	{
 		for(int i=0; i<(int)strlen(id.VolumeSet); i++)
 		{
-			isoDescriptor.volumeSetIdentifier[i] = 
+			isoDescriptor.volumeSetIdentifier[i] =
 				std::toupper(id.VolumeSet[i]);
 		}
 	}
@@ -1628,7 +1629,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 	{
 		for ( int i=0; i<(int)strlen(id.Publisher); i++ )
 		{
-			isoDescriptor.publisherIdentifier[i] = 
+			isoDescriptor.publisherIdentifier[i] =
 				std::toupper(id.Publisher[i]);
 		}
 	}
@@ -1643,18 +1644,18 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 	{
 		for ( int i=0; i<(int)strlen(id.DataPreparer); i++ )
 		{
-			isoDescriptor.dataPreparerIdentifier[i] = 
+			isoDescriptor.dataPreparerIdentifier[i] =
 				std::toupper( id.DataPreparer[i] );
 		}
 	}
-	
+
 	// Copyright (file) identifier
 	memset( isoDescriptor.copyrightFileIdentifier, 0x20, 128 );
 	if ( id.Copyright != nullptr )
 	{
 		for ( int i=0; i<(int)strlen(id.Copyright); i++ )
 		{
-			isoDescriptor.copyrightFileIdentifier[i] = 
+			isoDescriptor.copyrightFileIdentifier[i] =
 				std::toupper( id.Copyright[i] );
 		}
 	}
@@ -1677,12 +1678,12 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 	strcpy( isoDescriptor.volumeExpiryDate, "0000000000000000" );
 
 	isoDescriptor.fileStructVersion = 1;
-	
+
 	if ( !global::noXA )
 	{
 		strncpy( (char*)&isoDescriptor.appData[141], "CD-XA001", 8 );
 	}
-	
+
 	int pathTableLen = dirTree->CalculatePathTableLen();
 	int pathTableSectors = (pathTableLen+2047)/2048;
 
@@ -1694,9 +1695,9 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 	// Setup the root directory record
 	isoDescriptor.rootDirRecord.entryLength = 34;
 	isoDescriptor.rootDirRecord.extLength	= 0;
-	cd::SetPair32( &isoDescriptor.rootDirRecord.entryOffs, 
+	cd::SetPair32( &isoDescriptor.rootDirRecord.entryOffs,
 		18+(pathTableSectors*4) );
-	cd::SetPair32( &isoDescriptor.rootDirRecord.entrySize, 
+	cd::SetPair32( &isoDescriptor.rootDirRecord.entrySize,
 		2048*((dirTree->CalculateDirEntryLen()+2047)/2048) );
 	isoDescriptor.rootDirRecord.flags = 0x02;
 	cd::SetPair16( &isoDescriptor.rootDirRecord.volSeqNum, 1);
@@ -1714,7 +1715,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 	isoDescriptor.pathTable2Offs = isoDescriptor.pathTable1Offs+
 		pathTableSectors;
 	isoDescriptor.pathTable1MSBoffs = isoDescriptor.pathTable2Offs+1;
-	isoDescriptor.pathTable2MSBoffs = 
+	isoDescriptor.pathTable2MSBoffs =
 		isoDescriptor.pathTable1MSBoffs+pathTableSectors;
 	cd::SwapBytes( &isoDescriptor.pathTable1MSBoffs, 4 );
 	cd::SwapBytes( &isoDescriptor.pathTable2MSBoffs, 4 );
@@ -1724,7 +1725,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 	// Write the descriptor
 	writer->SeekToSector( 16 );
 	writer->SetSubheader( cd::IsoWriter::SubEOL );
-	writer->WriteBytes( &isoDescriptor, sizeof(cd::ISO_DESCRIPTOR), 
+	writer->WriteBytes( &isoDescriptor, sizeof(cd::ISO_DESCRIPTOR),
 		cd::IsoWriter::EdcEccForm1 );
 
 	// Write descriptor terminator;
@@ -1732,9 +1733,9 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 	isoDescriptor.header.type = 255;
 	isoDescriptor.header.version = 1;
 	strncpy( isoDescriptor.header.id, "CD001", 5 );
-	
+
 	writer->SetSubheader( cd::IsoWriter::SubEOF );
-	writer->WriteBytes( &isoDescriptor, sizeof(cd::ISO_DESCRIPTOR), 
+	writer->WriteBytes( &isoDescriptor, sizeof(cd::ISO_DESCRIPTOR),
 		cd::IsoWriter::EdcEccForm1 );
 
 	// Generate and write L-path table
@@ -1743,85 +1744,85 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, iso::IDENTIFIERS id,
 
 	dirTree->GeneratePathTable( sectorBuff, false );
 	writer->SetSubheader( cd::IsoWriter::SubData );
-	
+
 	for ( int i=0; i<pathTableSectors; i++ )
 	{
 		if ( i == pathTableSectors-1 )
 		{
 			writer->SetSubheader( cd::IsoWriter::SubEOF );
 		}
-		writer->WriteBytes( &sectorBuff[2048*i], 2048, 
+		writer->WriteBytes( &sectorBuff[2048*i], 2048,
 			cd::IsoWriter::EdcEccForm1 );
 	}
-	
+
 	writer->SetSubheader( cd::IsoWriter::SubData );
-	
+
 	for( int i=0; i<pathTableSectors; i++ )
 	{
 		if ( i == pathTableSectors-1 )
 		{
 			writer->SetSubheader( cd::IsoWriter::SubEOF );
 		}
-		writer->WriteBytes( &sectorBuff[2048*i], 2048, 
+		writer->WriteBytes( &sectorBuff[2048*i], 2048,
 			cd::IsoWriter::EdcEccForm1 );
 	}
-	
-	
+
+
 	// Generate and write M-path table
 	dirTree->GeneratePathTable( sectorBuff, true );
 	writer->SetSubheader( cd::IsoWriter::SubData );
-	
+
 	for ( int i=0; i<pathTableSectors; i++ )
 	{
 		if ( i == pathTableSectors-1 )
 		{
 			writer->SetSubheader( cd::IsoWriter::SubEOF );
 		}
-		writer->WriteBytes( &sectorBuff[2048*i], 2048, 
+		writer->WriteBytes( &sectorBuff[2048*i], 2048,
 			cd::IsoWriter::EdcEccForm1 );
 	}
-	
+
 	writer->SetSubheader( cd::IsoWriter::SubData );
-	
+
 	for ( int i=0; i<pathTableSectors; i++ )
 	{
 		if ( i == pathTableSectors-1 )
 		{
 			writer->SetSubheader( cd::IsoWriter::SubEOF );
 		}
-		writer->WriteBytes( &sectorBuff[2048*i], 2048, 
+		writer->WriteBytes( &sectorBuff[2048*i], 2048,
 			cd::IsoWriter::EdcEccForm1 );
 	}
-	
+
 	writer->SetSubheader( cd::IsoWriter::SubData );
 }
 
 iso::PathEntryClass::PathEntryClass() {
-	
+
 	dir_id = nullptr;
 	dir_level = 0;
 	dir_lba = 0;
-	
+
 	dir = nullptr;
 	sub = nullptr;
-			
+
 }
 
 iso::PathEntryClass::~PathEntryClass() {
-	
+
 	if ( sub != nullptr )
 	{
 		delete (PathTableClass*)sub;
 	}
-	
+
 }
 
 iso::PathTableClass::PathTableClass() {
-	
+
 }
 
 iso::PathTableClass::~PathTableClass() {
-	
+
 	if ( entries.size() > 0 )
 	{
 		for ( int i=0; i<entries.size(); i++ )
@@ -1829,16 +1830,16 @@ iso::PathTableClass::~PathTableClass() {
 			delete entries[i];
 		}
 	}
-	
+
 }
 
 unsigned char* iso::PathTableClass::GenTableData(unsigned char* buff, int msb) {
-	
+
 	if ( entries.size() == 0 )
 	{
 		return buff;
 	}
-	
+
 	for ( int i=0; i<entries.size(); i++ )
 	{
 		*buff = entries[i]->dir_id->length();	// Directory identifier length
@@ -1859,21 +1860,21 @@ unsigned char* iso::PathTableClass::GenTableData(unsigned char* buff, int msb) {
 		buff += 6;
 
 		// Put identifier (nullptr if first entry)
-		strncpy( (char*)buff, entries[i]->dir_id->c_str(), 
+		strncpy( (char*)buff, entries[i]->dir_id->c_str(),
 			entries[i]->dir_id->length() );
-		
+
 		buff += 2*((entries[i]->dir_id->length()+1)/2);
 	}
-	
+
 	for ( int i=0; i<entries.size(); i++ )
 	{
 		if ( entries[i]->sub )
 		{
 			buff = ((PathTableClass*)entries[i]->sub)->GenTableData( buff, msb );
 		}
-		
+
 	}
-	
+
 	return buff;
-	
+
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #include "cdwriter.h"	// CD image writer module
 #include "iso.h"		// ISO file system generator module
 
-#define VERSION "1.23"
+#define VERSION "1.24"
 
 
 namespace global
@@ -17,7 +17,7 @@ namespace global
 	int			NoLimit		= false;
 	int			trackNum	= 1;
 	int			noXA		= false;
-	
+
 	std::string	XMLscript;
 	std::string LBAfile;
 	std::string LBAheaderFile;
@@ -168,7 +168,7 @@ int main(int argc, const char* argv[])
     }
 
 	// Check if there is an <iso_project> element
-    tinyxml2::XMLElement* projectElement = 
+    tinyxml2::XMLElement* projectElement =
 		xmlFile.FirstChildElement( "iso_project" );
 
     if ( projectElement == nullptr )
@@ -210,19 +210,19 @@ int main(int argc, const char* argv[])
 		{
 			global::cuefile = projectElement->Attribute( "cue_sheet" );
 		}
-			
+
 		if ( !global::QuietMode )
 		{
 			printf( "Building ISO Image: %s", global::ImageName.c_str() );
-			
+
 			if ( global::cuefile )
 			{
 				printf( " + %s", global::cuefile );
 			}
-			
+
 			printf( "\n" );
 		}
-		
+
 		if ( projectElement->Attribute( "no_xa" ) != nullptr )
 		{
 			global::noXA = projectElement->IntAttribute( "no_xa", 0 );
@@ -257,7 +257,7 @@ int main(int argc, const char* argv[])
 
 
 		// Check if there is a track element specified
-		tinyxml2::XMLElement* trackElement = 
+		tinyxml2::XMLElement* trackElement =
 			projectElement->FirstChildElement( "track" );
 
 		if ( trackElement == nullptr )
@@ -280,9 +280,9 @@ int main(int argc, const char* argv[])
 					{
 						printf( "  " );
 					}
-					
+
 					printf( "ERROR: cue_sheet attribute is blank.\n" );
-					
+
 					return EXIT_FAILURE;
 				}
 
@@ -294,13 +294,13 @@ int main(int argc, const char* argv[])
 					{
 						printf( "  " );
 					}
-					
+
 					printf( "ERROR: Unable to create cue sheet.\n" );
 
 					return EXIT_FAILURE;
 				}
 
-				fprintf( cuefp, "FILE \"%s\" BINARY\n", 
+				fprintf( cuefp, "FILE \"%s\" BINARY\n",
 					global::ImageName.c_str() );
 			}
 		}
@@ -312,21 +312,21 @@ int main(int argc, const char* argv[])
 		if ( !global::NoIsoGen )
 		{
 			if ( !writer.Create( global::ImageName.c_str() ) ) {
-				
+
 				if ( !global::QuietMode )
 				{
 					printf( "  " );
 				}
-				
+
 				printf( "ERROR: Cannot open or create output image file.\n" );
-				
+
 				if ( cuefp != nullptr )
 				{
 					fclose( cuefp );
 				}
-				
+
 				return EXIT_FAILURE;
-				
+
 			}
 		}
 
@@ -338,32 +338,32 @@ int main(int argc, const char* argv[])
 		{
 			if ( !global::QuietMode )
 			{
-				printf( "  Track #%d %s:\n", global::trackNum, 
+				printf( "  Track #%d %s:\n", global::trackNum,
 					trackElement->Attribute("type") );
 			}
-			
+
 			if ( trackElement->Attribute( "type" ) == nullptr )
 			{
 				if ( !global::QuietMode )
 				{
 					printf( "  " );
 				}
-				
+
 				printf( "ERROR: type attribute not specified in <track> "
 					"element on line %d.\n", trackElement->GetLineNum() );
-				
+
 				if ( !global::NoIsoGen )
 				{
 					writer.Close();
 				}
-				
+
 				unlink( global::ImageName.c_str() );
 
 				if ( cuefp != nullptr )
 				{
 					fclose(cuefp);
 				}
-				
+
 				return EXIT_FAILURE;
 			}
 
@@ -379,17 +379,17 @@ int main(int argc, const char* argv[])
 
 					printf( "ERROR: Only the first track can be set as a "
 						"data track on line: %d\n", trackElement->GetLineNum() );
-					
+
 					if ( !global::NoIsoGen )
 					{
 						writer.Close();
 					}
-					
+
 					if ( cuefp != nullptr )
 					{
 						fclose( cuefp );
 					}
-					
+
 					return EXIT_FAILURE;
 				}
 
@@ -399,7 +399,7 @@ int main(int argc, const char* argv[])
 					{
 						writer.Close();
 					}
-					
+
 					unlink( global::ImageName.c_str() );
 
 					if ( cuefp != nullptr )
@@ -421,10 +421,10 @@ int main(int argc, const char* argv[])
 				{
 					printf("\n");
 				}
-				
+
 			// Add audio track
 			}
-			else if ( compare( "audio", 
+			else if ( compare( "audio",
 				trackElement->Attribute( "type" ) ) == 0 )
 			{
 
@@ -435,15 +435,15 @@ int main(int argc, const char* argv[])
 					{
 						printf( "    " );
 					}
-					
+
 					printf( "ERROR: cue_sheet attribute must be specified "
 						"when using audio tracks.\n" );
-					
+
 					if ( !global::NoIsoGen )
 					{
 						writer.Close();
 					}
-					
+
 					return EXIT_FAILURE;
 				}
 
@@ -454,20 +454,20 @@ int main(int argc, const char* argv[])
 					{
 						printf("    ");
 					}
-					
+
 					printf( "ERROR: source attribute not specified "
 						"for track on line %d.\n", trackElement->GetLineNum() );
-					
+
 					if ( !global::NoIsoGen )
 					{
 						writer.Close();
 					}
-					
+
 					if ( cuefp != nullptr )
 					{
 						fclose(cuefp);
 					}
-					
+
 					return EXIT_FAILURE;
 				}
 				else
@@ -481,12 +481,12 @@ int main(int argc, const char* argv[])
 						// Add PREGAP of 2 seconds on first audio track only
 						if ( ( !firstCDDAdone ) && ( global::trackNum < 3 ) )
 						{
-							
+
 							fprintf( cuefp, "    PREGAP 00:02:00\n" );
 							firstCDDAdone = true;
-							
+
 						} else {
-							
+
 							fprintf( cuefp, "    INDEX 00 %02d:%02d:%02d\n",
 								(trackLBA/75)/60, (trackLBA/75)%60,
 								trackLBA%75 );
@@ -498,7 +498,7 @@ int main(int argc, const char* argv[])
 							{
 								writer.WriteBytesRaw( blank, CD_SECTOR_SIZE );
 							}
-							
+
 							trackLBA += 150;
 
 						}
@@ -509,24 +509,24 @@ int main(int argc, const char* argv[])
 						// Pack the audio file
 						if ( !global::QuietMode )
 						{
-							printf( "    Packing audio %s... ", 
+							printf( "    Packing audio %s... ",
 								trackElement->Attribute( "source" ) );
 						}
-						
-						if ( PackWaveFile( &writer, 
+
+						if ( PackWaveFile( &writer,
 							trackElement->Attribute( "source" ) ) )
 						{
 							if ( !global::QuietMode )
 							{
 								printf( "Done.\n" );
 							}
-							
+
 						}
 						else
 						{
 							writer.Close();
 							fclose( cuefp );
-							
+
 							return EXIT_FAILURE;
 						}
 
@@ -538,7 +538,7 @@ int main(int argc, const char* argv[])
 				{
 					printf( "\n" );
 				}
-				
+
 			// If an unknown track type is specified
 			}
 			else
@@ -547,20 +547,20 @@ int main(int argc, const char* argv[])
 				{
 					printf( "    " );
 				}
-				
-				printf( "ERROR: Unknown track type on line %d.\n", 
+
+				printf( "ERROR: Unknown track type on line %d.\n",
 					trackElement->GetLineNum() );
-				
+
 				if ( !global::NoIsoGen )
 				{
 					writer.Close();
 				}
-				
+
 				if ( cuefp != nullptr )
 				{
 					fclose(cuefp);
 				}
-				
+
 				return EXIT_FAILURE;
 			}
 
@@ -580,11 +580,11 @@ int main(int argc, const char* argv[])
 			{
 				fclose( cuefp );
 			}
-			
+
 			if ( !global::QuietMode )
 			{
 				printf( "ISO image generated successfully.\n" );
-				printf( "Total image size: %d bytes (%d sectors)\n", 
+				printf( "Total image size: %d bytes (%d sectors)\n",
 					(CD_SECTOR_SIZE*totalImageSize), totalImageSize );
 			}
 		}
@@ -600,9 +600,9 @@ int main(int argc, const char* argv[])
 
 int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement* trackElement)
 {
-	tinyxml2::XMLElement* identifierElement = 
+	tinyxml2::XMLElement* identifierElement =
 		trackElement->FirstChildElement("identifiers");
-	tinyxml2::XMLElement* licenseElement = 
+	tinyxml2::XMLElement* licenseElement =
 		trackElement->FirstChildElement("license");
 
 	// Print out identifiers if present
@@ -613,17 +613,17 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 			printf("    Identifiers:\n");
 			if ( identifierElement->Attribute( "system" ) != nullptr )
 			{
-				printf( "      System       : %s\n", 
+				printf( "      System       : %s\n",
 					identifierElement->Attribute( "system" ) );
 			}
 			else
 			{
 				printf( "      System       : PLAYSTATION (default)\n" );
 			}
-			
+
 			if ( identifierElement->Attribute( "application" ) != nullptr )
 			{
-				printf( "      Application  : %s\n", 
+				printf( "      Application  : %s\n",
 					identifierElement->Attribute( "application" ) );
 			}
 			else
@@ -633,27 +633,27 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 
 			if ( identifierElement->Attribute( "volume" ) != nullptr )
 			{
-				printf( "      Volume       : %s\n", 
+				printf( "      Volume       : %s\n",
 					identifierElement->Attribute( "volume" ) );
 			}
 			if ( identifierElement->Attribute( "volumeset" ) != nullptr )
 			{
-				printf( "      Volume Set   : %s\n", 
+				printf( "      Volume Set   : %s\n",
 					identifierElement->Attribute( "volumeset" ) );
 			}
 			if ( identifierElement->Attribute( "publisher" ) != nullptr )
 			{
-				printf( "      Publisher    : %s\n", 
+				printf( "      Publisher    : %s\n",
 					identifierElement->Attribute( "publisher" ) );
 			}
 			if ( identifierElement->Attribute( "datapreparer" ) != nullptr )
 			{
-				printf( "      Data Preparer: %s\n", 
+				printf( "      Data Preparer: %s\n",
 					identifierElement->Attribute( "datapreparer" ) );
 			}
 			if ( identifierElement->Attribute( "copyright" ) != nullptr )
 			{
-				printf( "      Copyright    : %s\n", 
+				printf( "      Copyright    : %s\n",
 					identifierElement->Attribute( "copyright" ) );
 			}
 			printf( "\n" );
@@ -672,7 +672,7 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 				{
 					printf( "    " );
 				}
-				
+
 				printf("ERROR: file attribute of <license> element is missing "
 					"or blank on line %d\n.", licenseElement->GetLineNum() );
 
@@ -681,7 +681,7 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 
 			if ( !global::QuietMode )
 			{
-				printf( "    License file: %s\n\n", 
+				printf( "    License file: %s\n\n",
 					licenseElement->Attribute( "file" ) );
 			}
 
@@ -693,10 +693,10 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 				{
 					printf( "    " );
 				}
-				
+
 				printf( "ERROR: Specified license file not found on line %d.\n",
 					licenseElement->GetLineNum() );
-				
+
 				return false;
 
             }
@@ -718,7 +718,7 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 			{
 				printf( "    " );
 			}
-			
+
 			printf( "ERROR: <license> element has no file attribute on line %d.\n",
 				licenseElement->GetLineNum() );
 
@@ -733,7 +733,7 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 	{
 		printf( "    Parsing directory tree...\n" );
 	}
-	
+
 	iso::DirTreeClass dirTree;
 
 	if ( trackElement->FirstChildElement( "directory_tree" ) == nullptr )
@@ -756,10 +756,10 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 
 	// Calculate directory tree LBAs and retrieve size of image
 	int pathTableLen = dirTree.CalculatePathTableLen();
-	
-	int imageLen = dirTree.CalculateFileSystemSize( 
+
+	int imageLen = dirTree.CalculateFileSystemSize(
 		16+(((pathTableLen+2047)/2048)*4) );
-	
+
 	int totalLen = dirTree.CalculateTreeLBA(
 		18+(((pathTableLen+2047)/2048)*4) );
 
@@ -767,7 +767,7 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 	{
 		printf( "      Files Total: %d\n", dirTree.GetFileCountTotal() );
 		printf( "      Directories: %d\n", dirTree.GetDirCountTotal() );
-		printf( "      Total file system size: %d bytes (%d sectors)\n\n", 
+		printf( "      Total file system size: %d bytes (%d sectors)\n\n",
 			2352*totalLen, totalLen);
 	}
 
@@ -793,7 +793,7 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 
 		if ( !global::QuietMode )
 		{
-			printf( "    Wrote file LBA log %s.\n\n", 
+			printf( "    Wrote file LBA log %s.\n\n",
 				global::LBAfile.c_str() );
 		}
 	}
@@ -808,16 +808,16 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 
 		if ( !global::QuietMode )
 		{
-			printf( "    Wrote file LBA listing header %s.\n\n", 
+			printf( "    Wrote file LBA listing header %s.\n\n",
 				global::LBAheaderFile.c_str() );
 		}
 	}
-	
+
 	if ( cue_fp != nullptr )
 	{
 		fprintf( cue_fp, "  TRACK 01 MODE2/2352\n" );
 		fprintf( cue_fp, "    INDEX 01 00:00:00\n" );
-		
+
 		dirTree.WriteCueEntries( cue_fp, &global::trackNum );
 	}
 
@@ -831,11 +831,11 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 	{
 		printf( "    Building filesystem... " );
 	}
-	
+
 	//unsigned char subHead[] = { 0x00, 0x00, 0x08, 0x00 };
 	writer->SetSubheader( cd::IsoWriter::SubData );
 
-	if ( (global::NoLimit == false) && 
+	if ( (global::NoLimit == false) &&
 		(dirTree.CalculatePathTableLen() > 2048) )
 	{
 		if ( !global::QuietMode )
@@ -866,7 +866,7 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 	{
 		printf( "      Writing filesystem... " );
 	}
-	
+
 	// Sort directory entries and write it
 	dirTree.SortDirEntries();
 	dirTree.WriteDirectoryRecords( writer, 0 );
@@ -889,12 +889,12 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 		{
 			isoIdentifiers.SystemID = "PLAYSTATION";
 		}
-		
+
 		if ( isoIdentifiers.Application == nullptr )
 		{
 			isoIdentifiers.Application = "PLAYSTATION";
 		}
-		
+
 		if ( isoIdentifiers.Copyright == nullptr )
 		{
 			isoIdentifiers.Copyright = "COPYLEFTED";
@@ -908,7 +908,7 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 	{
 		printf( "Ok.\n" );
 	}
-	
+
 	// Write license data
 	if ( licenseElement != nullptr )
 	{
@@ -922,7 +922,7 @@ int ParseISOfileSystem(cd::IsoWriter* writer, FILE* cue_fp, tinyxml2::XMLElement
 		{
 			printf( "      Writing license data..." );
 		}
-		
+
 		iso::WriteLicenseData( writer, (void*)buff );
 
 		if ( !global::QuietMode )
@@ -940,12 +940,12 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 	std::string srcFile;
 	std::string name;
 	int found_da = false;
-	
+
 	if ( dirElement->Attribute( "srcdir" ) != nullptr )
 	{
 		srcDir = dirElement->Attribute( "srcdir" );
 	}
-	
+
 	if ( !srcDir.empty() )
 	{
 		while ( srcDir.rfind( "\\" ) != std::string::npos )
@@ -955,9 +955,9 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 		if ( srcDir.back() != '/' )
 		{
 			srcDir += "/";
-		}	
+		}
 	}
-	
+
 	dirElement = dirElement->FirstChildElement();
 
 	while ( dirElement != nullptr )
@@ -966,7 +966,7 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 		{
 			if ( ( dirElement->Attribute("name") == nullptr ) &&
 				( dirElement->Attribute("source") == nullptr ) ) {
-				
+
 				if ( !global::QuietMode )
 				{
 					printf("      ");
@@ -974,12 +974,12 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 
 				printf( "ERROR: Missing name and source attributes on "
 					"line %d.\n", dirElement->GetLineNum() );
-				
+
 				return false;
 			}
-			
+
 			srcFile = "";
-					
+
 			if ( dirElement->Attribute("source") != nullptr )
 			{
 				srcFile = dirElement->Attribute("source");
@@ -988,11 +988,11 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 					srcFile.replace( srcFile.rfind( "\\" ), 1, "/" );
 				}
 			}
-			
+
 			if ( dirElement->Attribute("name") )
 			{
 				name = dirElement->Attribute("name");
-			} 
+			}
 			else
 			{
 				if ( !srcFile.empty() )
@@ -1001,7 +1001,7 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 					name.erase( 0, name.rfind( '/' )+1 );
 				}
 			}
-			
+
 			if ( srcFile.empty() ) {
 				srcFile = name;
 			}
@@ -1010,9 +1010,9 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 			{
 				srcFile = srcDir + srcFile;
 			}
-			
-			
-			if ( ( name.find( '\\', 0 ) != std::string::npos ) 
+
+
+			if ( ( name.find( '\\', 0 ) != std::string::npos )
 				|| ( name.find( '/', 0 ) != std::string::npos ) )
 			{
 				if ( !global::QuietMode )
@@ -1021,7 +1021,7 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 				}
 
 				printf( "ERROR: Name attribute for file entry '%s' cannot be "
-					"a path on line %d.\n", name.c_str(), 
+					"a path on line %d.\n", name.c_str(),
 					dirElement->GetLineNum() );
 
 				return false;
@@ -1035,7 +1035,7 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 				}
 
 				printf( "ERROR: Name entry for file '%s' is more than 12 "
-					"characters long on line %d.\n", name.c_str(), 
+					"characters long on line %d.\n", name.c_str(),
 					dirElement->GetLineNum() );
 
 				return false;
@@ -1077,34 +1077,34 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 					{
 						printf( "      " );
 					}
-					
-					printf( "ERROR: Unknown type %s on line %d\n", 
-						dirElement->Attribute( "type" ), 
+
+					printf( "ERROR: Unknown type %s on line %d\n",
+						dirElement->Attribute( "type" ),
 						dirElement->GetLineNum() );
-					
+
 					return false;
 				}
-				
+
 				if ( ( found_da ) && ( entry != iso::EntryDA ) )
 				{
 					if ( !global::QuietMode )
 					{
 						printf( "      " );
 					}
-					
-					printf( "ERROR: Cannot place file past a DA audio file on line %d.\n", 
+
+					printf( "ERROR: Cannot place file past a DA audio file on line %d.\n",
 						dirElement->GetLineNum() );
-					
+
 					return false;
 				}
 
 			}
-			
+
 			if ( !dirTree->AddFileEntry( name.c_str(), entry, srcFile.c_str() ) )
 			{
 				return false;
 			}
-			
+
 		}
 		else if ( compare( "dummy", dirElement->Name() ) == 0 )
 		{
@@ -1120,7 +1120,7 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 
 				return false;
 			}
-			
+
 			dirTree->AddDummyEntry( atoi( dirElement->Attribute( "sectors" ) ) );
         }
 		else if ( compare( "dir", dirElement->Name() ) == 0 )
@@ -1137,7 +1137,7 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 
 				return false;
 			}
-			
+
 			if ( strlen( dirElement->Attribute( "name" ) ) > 12 )
 			{
 				printf( "ERROR: Directory name %s on line %d is more than 12 "
@@ -1146,14 +1146,14 @@ int ParseDirectory(iso::DirTreeClass* dirTree, tinyxml2::XMLElement* dirElement)
 				return false;
 			}
 
-			iso::DirTreeClass* subdir = dirTree->AddSubDirEntry( 
+			iso::DirTreeClass* subdir = dirTree->AddSubDirEntry(
 				dirElement->Attribute( "name" ) );
 
 			if ( subdir == nullptr )
 			{
 				return false;
 			}
-			
+
             if ( !ParseDirectory( subdir, dirElement ) )
 			{
 				return false;
@@ -1172,7 +1172,7 @@ int PackWaveFile(cd::IsoWriter* writer, const char* wavFile)
 	FILE *fp;
 	int waveLen;
 	unsigned char buff[CD_SECTOR_SIZE];
-	
+
 	if ( !( fp = fopen( wavFile, "rb" ) ) )
 	{
 		printf("ERROR: File not found.\n");
@@ -1189,14 +1189,14 @@ int PackWaveFile(cd::IsoWriter* writer, const char* wavFile)
 
 	fread( &HeaderChunk, 1, sizeof(HeaderChunk), fp );
 
-	if ( memcmp( &HeaderChunk.id, "RIFF", 4 ) || 
+	if ( memcmp( &HeaderChunk.id, "RIFF", 4 ) ||
 		memcmp( &HeaderChunk.format, "WAVE", 4 ) )
 	{
 		// Write data
 		fseek(fp, 0, SEEK_END);
 		waveLen = ftell(fp);
 		fseek(fp, 0, SEEK_SET);
-		
+
 		while ( waveLen > 0 )
 		{
 			memset(buff, 0x00, CD_SECTOR_SIZE);
@@ -1213,11 +1213,11 @@ int PackWaveFile(cd::IsoWriter* writer, const char* wavFile)
 
 			waveLen -= readLen;
 		}
-		
+
 		fclose( fp );
-		
+
 		printf("Packed as raw... ");
-		
+
 		return true;
 	}
 
@@ -1243,7 +1243,7 @@ int PackWaveFile(cd::IsoWriter* writer, const char* wavFile)
 		{
 			printf( "\n    " );
 		}
-		
+
 		printf( "ERROR: Unsupported WAV format.\n" );
 
 		fclose( fp );
@@ -1251,14 +1251,14 @@ int PackWaveFile(cd::IsoWriter* writer, const char* wavFile)
 	}
 
 
-    if ( (WAV_Subchunk1.chan != 2) || (WAV_Subchunk1.freq != 44100) || 
+    if ( (WAV_Subchunk1.chan != 2) || (WAV_Subchunk1.freq != 44100) ||
 		(WAV_Subchunk1.bps != 16) )
 	{
 		if ( !global::QuietMode )
 		{
 			printf( "\n    " );
 		}
-		
+
 		printf( "ERROR: Only 44.1KHz, 16-bit Stereo WAV files are supported.\n" );
 
 		fclose( fp );
@@ -1299,7 +1299,7 @@ int PackWaveFile(cd::IsoWriter* writer, const char* wavFile)
 		{
 			readLen = 2352;
 		}
-		
+
 		fread( buff, 1, readLen, fp );
 
         writer->WriteBytesRaw( buff, 2352 );
@@ -1320,7 +1320,7 @@ int GetSize(const char* fileName)
 	{
 		return -1;
 	}
-	
+
 	return fileAttrib.st_size;
 }
 
@@ -1330,7 +1330,7 @@ int compare( const char* a, const char* b )
 	{
 		return 1;
 	}
-	
+
 	for ( int i=0; a[i]!=0x00; i++ )
 	{
 		if ( std::tolower( a[i] ) != std::tolower( b[i] ) )
@@ -1338,6 +1338,6 @@ int compare( const char* a, const char* b )
 			return 1;
 		}
 	}
-	
+
 	return 0;
 }


### PR DESCRIPTION
This pull request fixes the way mkpsxiso constructs mixed mode files. There were two main issues.

One is that the sector mode was decided according to the DATA flag in the sub header. But this is not correct. There are XA files where the DATA flag is 0 (also the AUDIO, and VIDEO) actually, but the sector is still in mode 2 form 1. The real flag that guarantees the mode of the sector is, well, the mode flag. This has been fixed.

Second, when a mode2 form 2 sector is identified, now edc is properly generated. Before, it was not generated at all, leaving the sector with wrong edc data.
