### PR TITLE
macOS fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ include(FindPkgConfig)
 
 #set global exe name
 set(MAIN "mkpsxiso")
+set (CMAKE_CXX_STANDARD 11)
 
 project(${MAIN})
 #include directory, same for all build types
@@ -22,11 +23,11 @@ if(MINGW OR CYGWIN)
   
 elseif(MSYS OR MSVC)
   message(FATAL_ERROR "CAN NOT BUILD ON MICROSOFT COMPILER")
-  
-elseif(APPLE OR WATCOM OR BORLAND)
+
+elseif(WATCOM OR BORLAND)
   message(FATAL_ERROR "CAN NOT BUILD FOR APPLE, WATCOM, BORLAND")
   
-elseif(UNIX)
+elseif(UNIX OR APPLE)
   message(STATUS "UNIX BUILD")
 
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin_nix)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #include "cdwriter.h"	// CD image writer module
 #include "iso.h"		// ISO file system generator module
 
-#define VERSION "1.25"
+#define VERSION "1.26"
 
 
 namespace global


### PR DESCRIPTION
Specifying the C++ version was enough for me to get `mkpsxiso` building on macOS. I've also got a homebrew formula that I'll point to your upstream after this (hopefully) merges.