### PR TITLE
Path table extraction

### DIFF
--- a/src/dumpsxiso/cdreader.cpp
+++ b/src/dumpsxiso/cdreader.cpp
@@ -337,7 +337,7 @@ void cd::IsoDirEntries::ReadDirEntriesSkip(cd::IsoReader* reader, int lba, int s
 			}
 
 			// skip folders, we make them manually
-			if (numEntries++ >= 2 && !(entry->entry.flags & 0x2))
+			if (numEntries++ >= 2 && !(entry.value().entry.flags & 0x2))
 			{
 				dirEntryList.emplace(std::move(entry.value()));
 			}
@@ -349,12 +349,6 @@ void cd::IsoDirEntries::ReadDirEntriesSkip(cd::IsoReader* reader, int lba, int s
 		{
 			return left.get().entry.entryOffs.lsb < right.get().entry.entryOffs.lsb;
 		});
-}
-
-std::optional<cd::IsoDirEntries::Entry> cd::IsoDirEntries::ReadSingleEntry(cd::IsoReader* reader, int lba, int sectors)
-{
-    reader->SeekToSector(lba + sectors);
-		return ReadEntry(reader);
 }
 
 std::optional<cd::IsoDirEntries::Entry> cd::IsoDirEntries::ReadEntry(cd::IsoReader* reader) const

--- a/src/dumpsxiso/cdreader.h
+++ b/src/dumpsxiso/cdreader.h
@@ -100,9 +100,8 @@ namespace cd {
         ListView<Entry> dirEntryList;
 
         IsoDirEntries(ListView<Entry> view);
-        void ReadDirEntries(cd::IsoReader* reader, int lba, int sectors);
+        void ReadDirEntries(cd::IsoReader* reader, int lba, int sectors, bool skipFolders);
         void ReadRootDir(cd::IsoReader* reader, int lba);
-        void ReadDirEntriesSkip(cd::IsoReader* reader, int lba, int sectors);
 
 
     private:

--- a/src/dumpsxiso/cdreader.h
+++ b/src/dumpsxiso/cdreader.h
@@ -103,7 +103,6 @@ namespace cd {
         void ReadDirEntries(cd::IsoReader* reader, int lba, int sectors, bool skipFolders);
         void ReadRootDir(cd::IsoReader* reader, int lba);
 
-
     private:
         std::optional<Entry> ReadEntry(cd::IsoReader* reader) const;
     };

--- a/src/dumpsxiso/cdreader.h
+++ b/src/dumpsxiso/cdreader.h
@@ -103,7 +103,6 @@ namespace cd {
         void ReadDirEntries(cd::IsoReader* reader, int lba, int sectors);
         void ReadRootDir(cd::IsoReader* reader, int lba);
         void ReadDirEntriesSkip(cd::IsoReader* reader, int lba, int sectors);
-        std::optional<cd::IsoDirEntries::Entry> ReadSingleEntry(cd::IsoReader* reader, int lba, int sectors);
 
 
     private:

--- a/src/dumpsxiso/cdreader.h
+++ b/src/dumpsxiso/cdreader.h
@@ -102,6 +102,9 @@ namespace cd {
         IsoDirEntries(ListView<Entry> view);
         void ReadDirEntries(cd::IsoReader* reader, int lba, int sectors);
         void ReadRootDir(cd::IsoReader* reader, int lba);
+        void ReadDirEntriesSkip(cd::IsoReader* reader, int lba, int sectors);
+        std::optional<cd::IsoDirEntries::Entry> ReadSingleEntry(cd::IsoReader* reader, int lba, int sectors);
+
 
     private:
         std::optional<Entry> ReadEntry(cd::IsoReader* reader) const;

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -653,6 +653,7 @@ tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry, tinyx
 {
 	tinyxml2::XMLElement* newelement;
 
+			
 	const fs::path outputPath = sourcePath / entry.virtualPath / CleanIdentifier(entry.identifier);
 	const EntryType entryType = GetXAEntryType((entry.extData.attributes & cdxa::XA_ATTRIBUTES_MASK) >> 8);
 	if (entryType == EntryType::EntryDir)
@@ -690,6 +691,10 @@ tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry, tinyx
 
 		if (entryType == EntryType::EntryXA)
 		{
+			if (param::pathTable) {
+				 newelement->SetAttribute(xml::attrib::OFFSET, entry.entry.entryOffs.lsb);
+			}
+
 			newelement->SetAttribute(xml::attrib::ENTRY_TYPE, "mixed");
 		}
 		else if (entryType == EntryType::EntryDA)
@@ -698,6 +703,10 @@ tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry, tinyx
 		}
 		else if (entryType == EntryType::EntryFile)
 		{
+			if (param::pathTable) {
+				 newelement->SetAttribute(xml::attrib::OFFSET, entry.entry.entryOffs.lsb);
+			}
+
 			newelement->SetAttribute(xml::attrib::ENTRY_TYPE, "data");
 		}
 	}

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -1070,7 +1070,7 @@ int Main(int argc, char *argv[])
 		"  -S|--sort-by-dir - Outputs a \"pretty\" XML script where entries are grouped in directories, instead of strictly following their original order on the disc.\n"
 		"  -e|--encode <codec> - Codec to encode CDDA/DA audio. wave is default. Supported codecs: " SUPPORTED_CODEC_TEXT "\n"
 		"  -h|--help  - Show this help text\n"
-    "  -pt|--pathTable - instead of going throught the file system, go to every know directory in order; helps with deobfuscating\n";
+		"  -pt|--pathTable - instead of going throught the file system, go to every known directory in order; helps with deobfuscating\n";
 
     printf( "DUMPSXISO " VERSION " - PlayStation ISO dumping tool\n"
 			"2017 Meido-Tek Productions (John \"Lameguy\" Wilbert Villamor/Lameguy64)\n"

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -480,7 +480,7 @@ std::unique_ptr<cd::IsoDirEntries> ParsePathTable(cd::IsoReader& reader, ListVie
 
         if (entry.entry.flags & 0x2) {
 						int index = -1;
-						std::string s = "";
+						std::string s;
 						for (int i = 1; i < pathTableList.size(); i++) {
 								auto& ee = pathTableList[i];
 								if (ee.entry.dirOffs == entry.entry.entryOffs.lsb) {

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -1069,7 +1069,7 @@ int Main(int argc, char *argv[])
 		"  -S|--sort-by-dir - Outputs a \"pretty\" XML script where entries are grouped in directories, instead of strictly following their original order on the disc.\n"
 		"  -e|--encode <codec> - Codec to encode CDDA/DA audio. wave is default. Supported codecs: " SUPPORTED_CODEC_TEXT "\n"
 		"  -h|--help  - Show this help text\n"
-		"  -pt|--pathTable - instead of going throught the file system, go to every known directory in order; helps with deobfuscating\n";
+		"  -pt|--path-table - instead of going through the file system, go to every known directory in order; helps with deobfuscating\n";
 
     printf( "DUMPSXISO " VERSION " - PlayStation ISO dumping tool\n"
 			"2017 Meido-Tek Productions (John \"Lameguy\" Wilbert Villamor/Lameguy64)\n"
@@ -1087,7 +1087,7 @@ int Main(int argc, char *argv[])
 		// Is it a switch?
 		if ((*args)[0] == '-')
 		{
-			if (ParseArgument(args, "pt", "pathTable"))
+			if (ParseArgument(args, "pt", "path-table"))
 			{
         param::pathTable = true;
         continue;

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -876,7 +876,7 @@ void ParseISO(cd::IsoReader& reader) {
     size_t numEntries = pathTable.ReadPathTable(&reader, descriptor.pathTable1Offs);
 
 		std::vector<cd::IsoPathTable::Entry> sorted(pathTable.pathTableList);
-		std::sort(sorted.begin(), sorted.end(), [](auto& a, auto& b) {
+		std::sort(sorted.begin(), sorted.end(), [](const auto& a, const auto& b) {
 				return a.entry.dirOffs < b.entry.dirOffs;	
 		});
 

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -461,6 +461,7 @@ std::unique_ptr<cd::IsoDirEntries> ParsePathTable(cd::IsoReader& reader, ListVie
 						}
 
 						if (index < 0) continue;
+						entry.identifier = s;
 				
 						entry.subdir = ParsePathTable(reader, dirEntries->dirEntryList.NewView(), pathTableList, index, path / s);				
 				}

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -445,7 +445,6 @@ std::unique_ptr<cd::IsoDirEntries> ParsePathTable(cd::IsoReader& reader, ListVie
 	
 		do {
 			  dirEntries->ReadDirEntriesSkip(&reader, pathTableList[index].entry.dirOffs, sec);
-				printf("index: %d, secs: %d, len: %d\n", index, sec, dirEntries->dirEntryList.GetView().size());
 				if (dirEntries->dirEntryList.GetView().size() == 0) {
 					break;
 				}

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -431,9 +431,7 @@ std::unique_ptr<cd::IsoDirEntries> ParsePathTable(cd::IsoReader& reader, ListVie
    const fs::path& path) {
     auto dirEntries = std::make_unique<cd::IsoDirEntries>(std::move(view));
 
-		int sec = pathTableList[index].entry.extLength 
-				? pathTableList[index].entry.extLength 
-				: 1;		
+		int sec = std::max(1, (int)pathTableList[index].entry.extLength);
 
 		int sindex = -1;
 		for (int i = 1; i < pathTableList.size(); i++) {

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -681,7 +681,6 @@ tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry, tinyx
 {
 	tinyxml2::XMLElement* newelement;
 
-			
 	const fs::path outputPath = sourcePath / entry.virtualPath / CleanIdentifier(entry.identifier);
 	const EntryType entryType = GetXAEntryType((entry.extData.attributes & cdxa::XA_ATTRIBUTES_MASK) >> 8);
 	if (entryType == EntryType::EntryDir)

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -872,11 +872,10 @@ void ParseISO(cd::IsoReader& reader) {
     printf("\n");
 
     cd::IsoPathTable pathTable;
-		std::vector<cd::IsoPathTable::Entry> sorted;
 
     size_t numEntries = pathTable.ReadPathTable(&reader, descriptor.pathTable1Offs);
 
-		sorted = pathTable.pathTableList;
+		std::vector<cd::IsoPathTable::Entry> sorted(pathTable.pathTableList);
 		std::sort(sorted.begin(), sorted.end(), [](auto& a, auto& b) {
 				return a.entry.dirOffs < b.entry.dirOffs;	
 		});

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -410,7 +410,7 @@ std::unique_ptr<cd::IsoDirEntries> ParseSubdirectory(cd::IsoReader& reader, List
 	const fs::path& path)
 {
     auto dirEntries = std::make_unique<cd::IsoDirEntries>(std::move(view));
-    dirEntries->ReadDirEntries(&reader, offs, sectors);
+    dirEntries->ReadDirEntries(&reader, offs, sectors, false);
 
     for (auto& e : dirEntries->dirEntryList.GetView())
 	{
@@ -444,7 +444,7 @@ std::unique_ptr<cd::IsoDirEntries> ParsePathTable(cd::IsoReader& reader, ListVie
 		}
 	
 		do {
-			  dirEntries->ReadDirEntriesSkip(&reader, pathTableList[index].entry.dirOffs, sec);
+			  dirEntries->ReadDirEntries(&reader, pathTableList[index].entry.dirOffs, sec, true);
 				if (dirEntries->dirEntryList.GetView().size() == 0) {
 					break;
 				}

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -842,7 +842,7 @@ void ParseISO(cd::IsoReader& reader) {
 
 
 	std::list<cd::IsoDirEntries::Entry> entries;
-	std::unique_ptr<cd::IsoDirEntries> rootDir = (param::aggressive
+	std::unique_ptr<cd::IsoDirEntries> rootDir = (param::pathTable
 		?	ParseRootPathTable(reader, ListView(entries), pathTable.pathTableList)
 		: ParseRoot(reader,
 					ListView(entries),
@@ -1012,8 +1012,8 @@ int Main(int argc, char *argv[])
 		"  -s <path>  - Outputs an MKPSXISO compatible XML script for later rebuilding.\n"
 		"  -S|--sort-by-dir - Outputs a \"pretty\" XML script where entries are grouped in directories, instead of strictly following their original order on the disc.\n"
 		"  -e|--encode <codec> - Codec to encode CDDA/DA audio. wave is default. Supported codecs: " SUPPORTED_CODEC_TEXT "\n"
-		"  -h|--help  - Show this help text\n" +
-    "  -pt|--pathTable - instead of going throught the file system, go to every know directory in order; helps with deobfuscating";
+		"  -h|--help  - Show this help text\n"
+    "  -pt|--pathTable - instead of going throught the file system, go to every know directory in order; helps with deobfuscating\n";
 
     printf( "DUMPSXISO " VERSION " - PlayStation ISO dumping tool\n"
 			"2017 Meido-Tek Productions (John \"Lameguy\" Wilbert Villamor/Lameguy64)\n"

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -435,8 +435,6 @@ std::unique_ptr<cd::IsoDirEntries> ParsePathTable(cd::IsoReader& reader, ListVie
   
     for (auto& e : dirEntries->dirEntryList.GetView()) {
     		auto& entry = e.get();
-        printf("id: %s, path: %s, index: %d\n", entry.identifier.c_str(), path.c_str(), index);
-    
 
     		entry.virtualPath = path;
     }

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -622,7 +622,6 @@ bool iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer) const
 			{
 				if ( !global::QuietMode )
 				{
-					printf(" offset %d", entry.lba);
 					printf( "      Packing %" PRFILESYSTEM_PATH "... ", entry.srcfile.lexically_normal().c_str() );
 				}
 

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -342,6 +342,9 @@ void iso::DirTreeClass::PrintRecordPath()
 
 int iso::DirTreeClass::CalculateTreeLBA(int lba)
 {
+	int maxFlba = 0;
+	int sizeMax = 0;
+
 	bool firstDAWritten = false;
 	for ( DIRENTRY& entry : entries )
 	{
@@ -365,15 +368,21 @@ int iso::DirTreeClass::CalculateTreeLBA(int lba)
 			// Increment LBA by the size of file
 			if ( entry.type == EntryType::EntryFile || entry.type == EntryType::EntryXA_DO || entry.type == EntryType::EntryDummy )
 			{	
-				lba += (entry.flba)
-					? entry.flba - lba + GetSizeInSectors(entry.length, 2048)
-					: GetSizeInSectors(entry.length, 2048);					
+				if (entry.flba > maxFlba) {
+					maxFlba = entry.flba;
+					sizeMax = GetSizeInSectors(entry.length, 2048);
+				}
+
+				lba += GetSizeInSectors(entry.length, 2048);
 			}
 			else if ( entry.type == EntryType::EntryXA )
 			{
-				lba += (entry.flba)
-					? entry.flba - lba + GetSizeInSectors(entry.length, 2336)
-					: GetSizeInSectors(entry.length, 2336);					
+				if (entry.flba > maxFlba) {
+					maxFlba = entry.flba;
+					sizeMax = GetSizeInSectors(entry.length, 2336);
+				}
+
+				lba += GetSizeInSectors(entry.length, 2336);
 			}
 			else if ( entry.type == EntryType::EntryDA )
 			{
@@ -382,6 +391,8 @@ int iso::DirTreeClass::CalculateTreeLBA(int lba)
 			}
 		}
 	}
+	if (maxFlba)
+		return maxFlba + sizeMax;
 
 	return lba;
 }

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -33,6 +33,7 @@ namespace iso
 		std::string	id;		/// Entry identifier (empty if invisible dummy)
 		int64_t length;		/// Length of file in bytes
 		int		lba;		/// File LBA (in sectors)
+		int flba; /// Force LBA
 
 		fs::path srcfile;	/// Filename with path to source file (empty if directory or dummy)
 		EntryType	  type;		/// File type (0 - file, 1 - directory)

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -873,6 +873,7 @@ EntryAttributes ReadEntryAttributes(EntryAttributes current, const tinyxml2::XML
 		getAttributeIfExists(current.XAPerm, xml::attrib::XA_PERMISSIONS);
 		getAttributeIfExists(current.GID, xml::attrib::XA_GID);
 		getAttributeIfExists(current.UID, xml::attrib::XA_UID);
+		getAttributeIfExists(current.FLBA, xml::attrib::OFFSET);
 	}
 
 	return current;
@@ -1430,6 +1431,7 @@ bool ParseDirectory(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* pare
 {
 	for ( const tinyxml2::XMLElement* dirElement = parentElement->FirstChildElement(); dirElement != nullptr; dirElement = dirElement->NextSiblingElement() )
 	{
+		
         if ( CompareICase( "file", dirElement->Name() ))
 		{
 			if (!ParseFileEntry(dirTree, dirElement, xmlPath, defaultAttributes, found_da))

--- a/src/shared/common.h
+++ b/src/shared/common.h
@@ -35,6 +35,7 @@ private:
 	static constexpr unsigned char DEFAULT_XAATRIB = 0xFF;
 	static constexpr unsigned short DEFAULT_XAPERM = 0x555; // rx
 	static constexpr unsigned short	DEFAULT_OWNER_ID = 0;
+	static constexpr unsigned short	DEFAULT_FORCE_LBA = 0;
 
 public:
 	signed char GMTOffs = DEFAULT_GMTOFFS;
@@ -42,6 +43,7 @@ public:
 	unsigned short XAPerm = DEFAULT_XAPERM;
 	unsigned short GID = DEFAULT_OWNER_ID;
 	unsigned short UID = DEFAULT_OWNER_ID;
+	unsigned int FLBA = DEFAULT_FORCE_LBA;
 };
 
 // Helper functions for datestamp manipulation

--- a/src/shared/listview.h
+++ b/src/shared/listview.h
@@ -41,6 +41,12 @@ public:
 		std::sort(m_view.begin(), m_view.end(), std::forward<Compare>(comp));
 	}
 
+	void ClearView() {
+		size_t length = m_view.size();
+		m_view.clear();
+		m_list.resize(m_list.size() - length);
+	}
+
 	// Access to the view.
 	std::vector<std::reference_wrapper<type>>& GetView() { return m_view; }
 	const std::vector<std::reference_wrapper<type>>& GetView() const { return m_view; }

--- a/src/shared/xml.h
+++ b/src/shared/xml.h
@@ -32,6 +32,7 @@ namespace attrib
 	constexpr const char* ENTRY_NAME = "name";
 	constexpr const char* ENTRY_SOURCE = "source";
 	constexpr const char* ENTRY_TYPE = "type";
+	constexpr const char* OFFSET = "offs";
 
 	constexpr const char* LICENSE_FILE = "file";
 


### PR DESCRIPTION
Some games have obfuscated file systems such that while the path table contains most info about directories,
those directories won't be accessible from the root directory.

I've added the pathTable option that instead of going recursively through the file system, goes recursively through the path table and reads files from folder offset.

This causes some issues during repacking, as since the file system was obfuscated, game probably reads files by going to sector offset. I've fixed this by supplying the exact offset that the file was read to in the xml file, and writing that file to the written offset (if it exists, otherwise calculated).

This mr is potentially very good for modding, as it will allow more games to be unpacked, modified and repacked. (currently only tested on dmw3)

My c++ isn't very good so if you see anything stinky, please do request changes.