### PR TITLE
Bug fixes and improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Fetch repo contents
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: mkpsxiso
         submodules: recursive
@@ -22,7 +22,7 @@ jobs:
         cmake --build build --config Release -t package
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mkpsxiso-windows
         path: |
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends build-essential ninja-build
 
     - name: Fetch repo contents
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: mkpsxiso
         submodules: recursive
@@ -48,10 +48,10 @@ jobs:
     - name: Build and package mkpsxiso
       run: |
         cmake --preset ci -S mkpsxiso
-        cmake --build build -t package
+        cmake --build build --config Release -t package
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mkpsxiso-linux
         path: |
@@ -68,7 +68,7 @@ jobs:
     steps:
     - name: Fetch build artifacts
       if:   ${{ github.ref_type == 'tag' }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: .
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,17 +1,29 @@
 {
-	"version": 2,
+	"version": 3,
 	"cmakeMinimumRequired": {
 		"major": 3,
-		"minor": 20,
+		"minor": 19,
 		"patch": 0
 	},
 	"configurePresets": [
 		{
-			"name":        "default",
-			"displayName": "Default configuration",
+			"name":        "release",
+			"displayName": "Release build",
 			"description": "Use this preset when building mkpsxiso for local installation.",
-			"generator":   "Ninja",
-			"binaryDir":   "${sourceDir}/build"
+			"binaryDir":   "${sourceDir}/build",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Release"
+			}
+		},
+		{
+			"name":        "debug",
+			"displayName": "Debug configuration",
+			"description": "Use this preset when debugging mkpsxiso.",
+			"binaryDir":   "${sourceDir}/build",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Debug",
+				"CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG": "Debug"
+			}
 		},
 		{
 			"name":        "ci",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 1. Set up CMake and a compiler toolchain. Install the `cmake` and `build-essential` packages provided by your Linux distro, or one of the following kits on Windows:
    * MSVC (do not install CMake through the Visual Studio installer, download it from [here](https://cmake.org/download) instead)
-   * MSys2 (use the "MinGW 64-bit" shell) with the following packages: `git`, `mingw-w64-x86_64-make`, `mingw-w64-x86_64-cmake`, `mingw-w64-x86_64-g++`
+   * MSys2 (use the "MinGW 64-bit" shell) with the following packages: `git`, `mingw-w64-x86_64-make`, `mingw-w64-x86_64-cmake`, `mingw-w64-x86_64-gcc`
    * Cygwin64 with the following packages: `git`, `make`, `cmake`, `gcc`
 
 2. Clone/download the repo, then run the following command from the mkpsxiso directory to ensure `tinyxml2` is also downloaded and updated:
@@ -45,8 +45,8 @@
 3. Run the following commands:
 
    ```bash
-   cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release
-   cmake --build ./build
+   cmake -S . --preset release
+   cmake --build ./build --config Release
    cmake --install ./build
    ```
 

--- a/examples/example.xml
+++ b/examples/example.xml
@@ -26,11 +26,13 @@
 		
 		Attributes:
 			type		- Track type (either data or audio).
+			xa_edc		- For data track only, specifies if the image has (yes) or no (no) EDC in Form 2 sectors.
+						  If xa_edc is not specified, defaults to 'yes'.
 			source		- For audio tracks only, specifies the file name of a wav audio
 						  file as source data for the audio track.
 			
 	-->
-	<track type="data">
+	<track type="data" xa_edc="yes">
 	
 		<!-- <identifiers>
 			Optional, Specifies the identifier strings for the data track.
@@ -159,8 +161,12 @@
 				
 				Attributes:
 					sectors	- Size of dummy file in sector units (1024 = 2MB).
+					xa_perm	- The dummy's subhead value. Values between 0-255 only
+								 '0': for a Form 1 dummy (0x00).
+								'32': for a Form 2 dummy (0x20).
+							If xa_perm is not specified, defaults to '0'.
 			-->
-			<dummy sectors="1024"/>
+			<dummy sectors="1024" xa_perm="0"/>
 			
 			<!-- Sample DA audio file entry.
 			

--- a/src/dumpsxiso/cdreader.h
+++ b/src/dumpsxiso/cdreader.h
@@ -40,11 +40,13 @@ namespace cd {
         // Open ISO image
         bool Open(const fs::path& fileName);
 
-        // Read data sectors in bytes (supports sequential reading)
+        // Read form1 data(2048) sector in bytes (supports sequential reading)
         size_t ReadBytes(void* ptr, size_t bytes, bool singleSector = false);
 
+        // Read form2 subheader+data+edc(2336) sector in bytes (supports sequential reading)
         size_t ReadBytesXA(void* ptr, size_t bytes, bool singleSector = false);
 
+        // Read whole(2352) sector in bytes (supports sequential reading)
         size_t ReadBytesDA(void* ptr, size_t bytes, bool singleSector = false);
 
         // Skip bytes in data sectors (supports sequential skipping)

--- a/src/mkpsxiso/cdwriter.h
+++ b/src/mkpsxiso/cdwriter.h
@@ -36,7 +36,7 @@ public:
 
 		virtual void WriteFile(FILE* file) = 0;
 		virtual void WriteMemory(const void* memory, size_t size) = 0;
-		virtual void WriteBlankSectors(unsigned int count) = 0;
+		virtual void WriteBlankSectors(unsigned int count, const uint8_t subhead = 32) = 0;
 		virtual size_t GetSpaceInCurrentSector() const = 0;
 		virtual void NextSector() = 0;
 		virtual void SetSubheader(unsigned int subHead) = 0;

--- a/src/mkpsxiso/global.h
+++ b/src/mkpsxiso/global.h
@@ -5,10 +5,11 @@
 
 namespace global {
 
-	extern time_t	BuildTime;
-	extern int		QuietMode;
-	extern int		noXA;
-	extern int		trackNum;
+	extern time_t		BuildTime;
+	extern const char*	xa_edc;
+	extern int			QuietMode;
+	extern int			trackNum;
+	extern int			noXA;
 };
 
 #endif // _GLOBAL_H

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -125,9 +125,9 @@ namespace iso
 		 *	is not actually added to the directory record.
 		 *
 		 *	sectors	- The size of the dummy file in sector units (1 = 2048 bytes, 1024 = 2MB).
-		 *  type	- 0 for form1 (data) dummy, 1 for form2 (XA) dummy
+		 *  subhead	- 0x00 (0) for form1 (data) dummy, 0x20 (32) for form2 (XA) dummy
 		 */
-		void AddDummyEntry(int sectors, int type);
+		void AddDummyEntry(const int sectors, const uint8_t subhead);
 
 		/** Generates a path table of all directories and subdirectories within this class' directory record.
 		 *

--- a/src/shared/common.cpp
+++ b/src/shared/common.cpp
@@ -18,7 +18,9 @@ static void snprintfZeroPad(char* s, size_t n, const char* format, ...)
 
 	const int bytesWritten = vsnprintf(buf.get(), n + 1, format, args);
 	memcpy(s, buf.get(), bytesWritten);
-	std::fill(s + bytesWritten, s + n, '\0');
+	if (bytesWritten < n) {
+		std::fill(s + bytesWritten, s + n, '\0');
+	}
 
 	va_end(args);
 }

--- a/src/shared/platform.cpp
+++ b/src/shared/platform.cpp
@@ -49,9 +49,19 @@ static FILETIME TimetToFileTime(time_t t)
 	return ft;
 }
 
-time_t timegm(struct tm* tm)
-{
-	return _mkgmtime(tm);
+static time_t FileTimeToTimet(const FILETIME& ft) {
+    LARGE_INTEGER ll;
+    ll.LowPart = ft.dwLowDateTime;
+    ll.HighPart = ft.dwHighDateTime;
+    return (ll.QuadPart / 10000000LL) - 11644473600LL;
+}
+
+HANDLE HandleFile(const fs::path& path) {
+	HANDLE hFile = CreateFileW(path.c_str(), FILE_WRITE_ATTRIBUTES, 0, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+	if (hFile != INVALID_HANDLE_VALUE) {
+		return hFile;
+	}
+	return nullptr;
 }
 #endif
 
@@ -87,6 +97,120 @@ int64_t GetSize(const fs::path& path)
 	return fileAttrib.has_value() ? fileAttrib->st_size : -1;
 }
 
+// Determines if a year is a leap year
+bool IsLeapYear(int year) {
+    return (year % 4 == 0) && (year % 100 != 0 || year % 400 == 0);
+}
+
+// Calculates the number of days in a given month
+int DaysInMonth(int month, int year) {
+    static const int month_days[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+    return (month == 1 && IsLeapYear(year)) ? 29 : month_days[month];
+}
+
+// Converts struct tm to time_t
+time_t CustoMkTime(struct tm* timebuf) {
+	int days = 0;
+
+	// Calculates the number of days from 1900 to a given date
+    for (int y = 1900; y < timebuf->tm_year + 1900; ++y) {
+        days += IsLeapYear(y) ? 366 : 365;
+    }
+    for (int m = 0; m < timebuf->tm_mon; ++m) {
+        days += DaysInMonth(m, timebuf->tm_year + 1900);
+    }
+	
+	// Calculate days from 1900 to the given date minus days from 1900 to 1970
+    int days_since_epoch = days + timebuf->tm_mday - 1 - 25567;
+
+    // Convert days and time to seconds
+    time_t total_seconds = static_cast<time_t>(days_since_epoch) * 86400 + timebuf->tm_hour * 3600 + timebuf->tm_min * 60 + timebuf->tm_sec;
+
+    // Adjust total_seconds to UTC 0
+	const time_t now = time(nullptr);
+    total_seconds -= (now - mktime(gmtime(&now)));
+
+    return total_seconds;
+}
+
+// Converts time_t to struct tm
+struct tm CustomLocalTime(time_t seconds) {
+    struct tm timebuf = {0};
+	const time_t now = time(nullptr);
+	seconds += (now - mktime(gmtime(&now)));
+
+    // Calculate the number of days since the epoch
+    int remaining_seconds = seconds % 86400;
+	if (remaining_seconds < 0) {
+		remaining_seconds += 86400;
+	}
+	int total_days = (seconds - remaining_seconds) / 86400 + 25567; // 25567 = days from 1900 to 1970
+
+    // Calculate year
+    int year = 1900;
+    while (true) {
+        int days_in_year = IsLeapYear(year) ? 366 : 365;
+        if (total_days < days_in_year) {
+			break;
+		}
+        total_days -= days_in_year;
+        ++year;
+    }
+	timebuf.tm_year = year - 1900;
+
+    // Calculate month
+    int month = 0;
+    while (true) {
+        int days_in_current_month = DaysInMonth(month, year);
+        if (total_days < days_in_current_month) {
+			break;
+		}
+        total_days -= days_in_current_month;
+        ++month;
+    }
+    timebuf.tm_mon = month;
+
+	// Calculate days
+    timebuf.tm_mday = total_days + 1;
+
+    // Calculate hour, minute, second
+    timebuf.tm_hour = remaining_seconds / 3600;
+    remaining_seconds %= 3600;
+    timebuf.tm_min = remaining_seconds / 60;
+    timebuf.tm_sec = remaining_seconds % 60;
+    timebuf.tm_isdst = 0;
+
+    return timebuf;
+}
+
+bool GetSrcTime(const fs::path& path, time_t& outTime) {
+#ifdef _WIN32
+	
+    if (HANDLE hFile = HandleFile(path)) {
+        
+	    FILETIME ftCreation, ftLastAccess, ftLastWrite;
+	    if (!GetFileTime(hFile, &ftCreation, &ftLastAccess, &ftLastWrite)) {
+			printf("ERROR: unable to get timestamps for %ls\n", path.c_str());
+        	CloseHandle(hFile);
+        	return false;
+    	}
+    	CloseHandle(hFile);
+
+    	// Convert from 100-nanosecond intervals since January 1, 1601 to seconds since January 1, 1970
+    	outTime = FileTimeToTimet(ftCreation);
+    	return true;
+	}
+	return false;
+#else
+	struct stat64 fileAttrib;
+    if (stat64(path.c_str(), &fileAttrib) != 0) {
+        return false;
+    }
+
+    outTime = fileAttrib.st_ctime;
+    return true;
+#endif
+}
 
 void UpdateTimestamps(const fs::path& path, const cd::ISO_DATESTAMP& entryDate)
 {
@@ -95,22 +219,21 @@ void UpdateTimestamps(const fs::path& path, const cd::ISO_DATESTAMP& entryDate)
 	timeBuf.tm_mon = entryDate.month - 1;
 	timeBuf.tm_mday = entryDate.day;
 	timeBuf.tm_hour = entryDate.hour;
-	timeBuf.tm_min = entryDate.minute - (15 * entryDate.GMToffs);
+	timeBuf.tm_min = entryDate.minute;
 	timeBuf.tm_sec = entryDate.second;
-	const time_t time = timegm(&timeBuf);
+	const time_t time = CustoMkTime(&timeBuf);
 
 // utime can't update timestamps of directories on Windows, so a platform-specific approach is needed
 #ifdef _WIN32
-	HANDLE file = CreateFileW(path.c_str(), FILE_WRITE_ATTRIBUTES, 0, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
-	if (file != INVALID_HANDLE_VALUE)
-	{
+
+	if (HANDLE hFile = HandleFile(path)) {
 		const FILETIME ft = TimetToFileTime(time);
-		if(0 == SetFileTime(file, &ft, nullptr, &ft))
+		if(0 == SetFileTime(hFile, &ft, nullptr, &ft))
 		{
 			printf("ERROR: unable to update timestamps for %ls\n", path.c_str());
 		}
 
-		CloseHandle(file);
+		CloseHandle(hFile);
 	}
 #else
 	struct timespec times[2];

--- a/src/shared/platform.h
+++ b/src/shared/platform.h
@@ -32,3 +32,6 @@ FILE* OpenFile(const fs::path& path, const char* mode);
 std::optional<struct stat64> Stat(const fs::path& path);
 int64_t GetSize(const fs::path& path);
 void UpdateTimestamps(const fs::path& path, const cd::ISO_DATESTAMP& entryDate);
+time_t CustoMkTime(struct tm* timebuf);
+struct tm CustomLocalTime(time_t seconds);
+bool GetSrcTime(const fs::path& path, time_t& outTime);

--- a/src/shared/xml.h
+++ b/src/shared/xml.h
@@ -25,6 +25,7 @@ namespace attrib
 	constexpr const char* NO_XA = "no_xa";
 
 	constexpr const char* TRACK_TYPE = "type";
+	constexpr const char* XA_EDC = "xa_edc";
 	constexpr const char* TRACK_SOURCE = "source";
 	constexpr const char* TRACK_ID = "trackid";
 	constexpr const char* PREGAP_DURATION = "duration";


### PR DESCRIPTION
Updated Actions

Created a release and debug cmake profile

Updated readme compile instruccions

Update example.xml for the new format

Avoid read funcionts being call past EoF

Fixed some compiling warnings

Added ability to maintain EDC Form 2 integrity via xml, fixes this #46 

Fix posible crash if end map iterator cannot be dereferenced

Dummy sectors now saves the subheader value to the xml, so it can regenerate the correct values for non-standart (0x00/0x20) sectors

Added a HACK to check if there is a post gap dummy and some warnings if the gap is a non-standart 150 one, fixes this #44 

Now outputs by default an .xml file with the name of the input is no -s arg is given, this is a QOL for easy drag & drop

Fixed calculation length of dir/file entries, fixes this #52 and this #23 

Removed some duplicated lines

Dirs entries are now sort before the calculation of LBA tree

Now the program supports read/update timestamps prior to 1970 in windows

Now files are extracted/built with the original timestamps instead of being offsetted previously and then re calculated at build time. This is for better compatibily with other CD authoring tools