### PR TITLE
Fix crash (assert) caused by unsafe dereference of std::optional<bool>

### DIFF
--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -98,7 +98,7 @@ iso::DIRENTRY& iso::DirTreeClass::CreateRootDirectory(EntryList& entries, const 
 	entry.type		= EntryType::EntryDir;
 	entry.subdir	= std::make_unique<DirTreeClass>(entries);
 	entry.date		= volumeDate;
-	if (!*global::new_type) {
+	if (!global::new_type.value_or(false)) {
 		entry.date.year = volumeDate.year % 0x64; // Root overflows dates past 1999 for games built with old(<2003) mastering tool
 	}
 	entry.length	= 0; // Length is meaningless for directories
@@ -589,7 +589,7 @@ bool iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& d
 		const DIRENTRY& entry = e.get();
 		if ( !entry.id.empty() )
 		{
-			if (*global::new_type && this->name != "<root>" && entry.type == EntryType::EntryDir) {
+			if (global::new_type.value_or(false) && this->name != "<root>" && entry.type == EntryType::EntryDir) {
 				dirQueue.push(entry);
 			}
 			else {
@@ -1081,10 +1081,10 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 
 	// Write the descriptor
 	unsigned int currentHeaderLBA = 16;
-	const unsigned char ISOver = *global::new_type ? 1 : 0;
+	const unsigned char ISOver = global::new_type.value_or(false) ? 1 : 0;
 
 	auto isoDescriptorSectors = writer->GetSectorViewM2F1(currentHeaderLBA, 2 + ISOver, cd::IsoWriter::EdcEccForm::Form1);
-	isoDescriptorSectors->SetSubheader(*global::new_type ? cd::IsoWriter::SubData : cd::IsoWriter::SubEOL);
+	isoDescriptorSectors->SetSubheader(global::new_type.value_or(false) ? cd::IsoWriter::SubData : cd::IsoWriter::SubEOL);
 
 	isoDescriptorSectors->WriteMemory(&isoDescriptor, sizeof(isoDescriptor));
 

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -852,7 +852,7 @@ int Main(int argc, char* argv[])
 			}
 
 			// Write directory entries
-			dirTree->WriteDirectoryRecords( &writer, root, root, *global::new_type ? dirTree->GetDirCountTotal() : 0 );
+			dirTree->WriteDirectoryRecords( &writer, root, root, global::new_type.value_or(false) ? dirTree->GetDirCountTotal() : 0 );
 
 			// Write file system descriptors to finish the image
 	        iso::WriteDescriptor( &writer, isoIdentifiers, root, totalLenLBA );
@@ -1205,7 +1205,7 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 	const int rootLBA = 18+(GetSizeInSectors(pathTableLen)*4);
 
 	// Sort directory entries, calculate tree LBAs and retrieve size of image
-	if (!*global::new_type) {
+	if (!global::new_type.value_or(false)) {
 		dirTree->SortDirectoryEntries();
 	}
 	totalLen = dirTree->CalculateTreeLBA(rootLBA);


### PR DESCRIPTION
This fixes a runtime crash (assert) in mkpsxiso where an std::optional<bool> was dereferenced without checking if it contained a value (i.e., nullopt), e.g. via *optional or optional.value().

While this was undefined behavior in earlier C++ versions, it went unnoticed in older GCC versions. Starting from GCC 13+ (and strictly enforced in GCC 15), libstdc++ adds runtime assertions to std::optional::operator* and value(), causing an immediate crash when dereferencing a disengaged optional.