### PR TITLE
Fix xml path issue on Windows

### DIFF
--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -224,7 +224,6 @@ int Main(int argc, char* argv[])
 		tinyxml2::XMLError error;
 		if (FILE* file = OpenFile(global::XMLscript, "rb"); file != nullptr)
 		{
-			global::XMLscript = fs::relative(global::XMLscript);
 			error = xmlFile.LoadFile(file);
 			fclose(file);
 		}


### PR DESCRIPTION
I forgot to remove this debug line
Although it doesn't hurt on Linux, on Windows returns an empty path if the file path is on a different drive than the current working directory.
Replacing it with `proximate` would solve the issue, but since this doesn't affect outputs and was only for prettier watch expressions, it's better to remove it.