### PR TITLE
Fix Windows crash with pre-1970 timestamps on legacy XMLs

### DIFF
--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -24,7 +24,7 @@ static const int RoundToEven(const int val)
 
 static cd::ISO_DATESTAMP GetISODateStamp(time_t time, signed char GMToffs)
 {
-	tm timestamp;
+	tm* timestamp;
 	if (global::new_type.has_value()) {
 		timestamp = CustomLocalTime(&time);
 	}
@@ -32,17 +32,19 @@ static cd::ISO_DATESTAMP GetISODateStamp(time_t time, signed char GMToffs)
 		// GMToffs is specified in 15 minute units
 		const time_t GMToffsSeconds = static_cast<time_t>(15) * 60 * GMToffs;
 		time += GMToffsSeconds;
-		timestamp = *gmtime( &time );
+		timestamp = gmtime( &time );
 	}
 
-	cd::ISO_DATESTAMP result;
-	result.hour		= timestamp.tm_hour;
-	result.minute	= timestamp.tm_min;
-	result.second	= timestamp.tm_sec;
-	result.month	= timestamp.tm_mon+1;
-	result.day		= timestamp.tm_mday;
-	result.year		= timestamp.tm_year;
-	result.GMToffs	= GMToffs;
+	cd::ISO_DATESTAMP result{.month = 1, .day = 1, .GMToffs = GMToffs};
+	if (timestamp != nullptr)
+	{
+		result.year		= timestamp->tm_year;
+		result.month	= timestamp->tm_mon + 1;
+		result.day		= timestamp->tm_mday;
+		result.hour		= timestamp->tm_hour;
+		result.minute	= timestamp->tm_min;
+		result.second	= timestamp->tm_sec;
+	}
 
 	return result;
 }

--- a/src/shared/platform.cpp
+++ b/src/shared/platform.cpp
@@ -92,10 +92,10 @@ int64_t GetSize(const fs::path& path)
 }
 
 // Returns local UTC `struct tm` from UTC+0 `time_t`
-struct tm CustomLocalTime(const time_t* timeSec)
+struct tm* CustomLocalTime(const time_t* timeSec)
 { // Windows localtime() can't handle timestamps prior to 1970
 #ifdef _WIN32
-	tm timeBuf {};
+	static tm timeBuf {};
 	SYSTEMTIME localST {};
 	FILETIME localFT = TimetToFileTime(*timeSec - SYSTEM_TIMEZONE);
 	FileTimeToSystemTime(&localFT, &localST);
@@ -107,9 +107,9 @@ struct tm CustomLocalTime(const time_t* timeSec)
 	timeBuf.tm_min  = localST.wMinute;
 	timeBuf.tm_sec  = localST.wSecond;
 
-	return timeBuf;
+	return &timeBuf;
 #else
-	return *localtime(timeSec);
+	return localtime(timeSec);
 #endif
 }
 

--- a/src/shared/platform.h
+++ b/src/shared/platform.h
@@ -23,4 +23,4 @@ std::optional<struct stat64> Stat(const fs::path& path);
 int64_t GetSize(const fs::path& path);
 void UpdateTimestamps(const fs::path& path, const cd::ISO_DATESTAMP& entryDate);
 time_t CustomMkTime(struct tm* timeBuf);
-struct tm CustomLocalTime(const time_t* timeSec);
+struct tm* CustomLocalTime(const time_t* timeSec);


### PR DESCRIPTION
On Windows, `gmtime()` returns `nullptr` for `time_t` values lower than `-43200` (pre-1970), causing a crash when dereferencing the result.
This affects only legacy XMLs where `global::new_type` is null.