### PR TITLE
Infer source paths from directory structure and simplify XML generation

### DIFF
--- a/examples/example.xml
+++ b/examples/example.xml
@@ -104,9 +104,9 @@
 							  This setting doesn't modify the LBA and is per directory. If order is not specified, defaults to '0'.
 							  So, files/folders with order < 0 will be before the unordered ones and after them the ones with order > 0.
 				
-				Note: Either name or source attribute can be omitted. If only name is specified, it uses that as the
-				name of the source file (must be in the root directory), and specifying only source strips off the
-				path name and uses that as the name of the file. Omitting both will cause an error obviously.
+				Note: Either name or source attribute can be omitted. If only name is specified, it uses
+				that as the name of the source file, and specifying only source strips off the path name
+				and uses that as the name of the file. Omitting both will cause an error obviously.
 			-->
 			<!-- Stores system.txt as system.cnf -->
 			<file name="system.cnf"	type="data"	source="system.txt"/>

--- a/examples/example.xml
+++ b/examples/example.xml
@@ -76,6 +76,11 @@
 		
 		<!-- <directory_tree>
 			Specifies and contains the directory structure for the data track.
+			
+			Attributes:
+				source	- Optional, specifies the directory path to the source files if no source attribute is
+						  specified to the <file> elements (optional, take note that it does not behave
+						  like cd or chdir and must be a complete path, can be a relative or absolute path).
 		-->
 		<directory_tree>
 		
@@ -119,7 +124,7 @@
 				
 				Attributes:
 					name	- Specifies the name of the subdirectory.
-					srcdir	- Specifies the directory path to the source files if no source attribute is
+					source	- Specifies the directory path to the source files if no source attribute is
 							  specified to the <file> elements (optional, can be a relative or absolute path).
 					hidden	- Optional, flag to set files/directories as "hidden" (see above for description).
 					order	- Optional, custom Directory Record order (see above for description).
@@ -181,7 +186,7 @@
 				A DA file must have a trackid that matches with with a <track>. The trackid is just a
 				string.
 				
-				You can still use <dummy> or <track> elements after this, if you want to add further audio tracks
+				You can still use <track> elements after this, if you want to add further audio tracks
 				that are not referenced by any DA file in the data track.
 			-->
 			<file name="audio1.da" trackid="02" type="da"/>

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -1491,7 +1491,7 @@ int Main(int argc, char *argv[])
 
 	if (param::xmlFile.empty())
 	{
-		param::xmlFile = param::isoFile.stem() += ".xml";
+		param::xmlFile = param::outPath.stem() += ".xml";
 	}
 
 	if (CompareICase(param::isoFile.extension().string(), ".cue"))

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -897,19 +897,26 @@ tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry, tinyx
 {
 	tinyxml2::XMLElement* newelement;
 
-	const fs::path outputPath = sourcePath / entry.virtualPath / CleanIdentifier(entry.identifier);
 	if (entry.type == EntryType::EntryDir)
 	{
 		if (!entry.identifier.empty())
 		{
 			newelement = dirElement->InsertNewChildElement("dir");
 			newelement->SetAttribute(xml::attrib::ENTRY_NAME, entry.identifier.c_str());
-			newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, outputPath.generic_string().c_str());
+			if (param::lba)
+			{
+				const fs::path outputPath = sourcePath / entry.virtualPath / CleanIdentifier(entry.identifier);
+				newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, outputPath.generic_string().c_str());
+			}
 		}
 		else
 		{
 			// Root directory
 			newelement = dirElement->InsertNewChildElement(xml::elem::DIRECTORY_TREE);
+			if (!param::lba)
+			{
+				newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, sourcePath.generic_string().c_str());
+			}
 		}
 
 		dirElement = newelement;
@@ -924,7 +931,11 @@ tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry, tinyx
 		newelement->SetAttribute(xml::attrib::ENTRY_NAME, CleanIdentifier(entry.identifier).c_str());
 		if(entry.type != EntryType::EntryDA)
 		{
-			newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, outputPath.generic_string().c_str());
+			if (param::lba)
+			{
+				const fs::path outputPath = sourcePath / entry.virtualPath / CleanIdentifier(entry.identifier);
+				newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, outputPath.generic_string().c_str());
+			}
 			newelement->SetAttribute(xml::attrib::ENTRY_TYPE, entry.type == EntryType::EntryFile ? "data" : "mixed");	
 		}
 		else
@@ -1349,7 +1360,7 @@ int Main(int argc, char *argv[])
 		"  -pt|--path-table\tGo through every known directory in order; helps on soft obfuscated games (like DMW3)\n"
 		"  -f|--force\t\tScans all unknown sectors for files; helps on heavy obfuscated games (like Xenogears)\n"
 		"  -e|--encode <codec>\tCodec to encode CDDA/DA audio; supports " SUPPORTED_CODEC_TEXT " (defaults to wave)\n"
-		"  -l|--lba\t\tWrites all lba offsets in the xml to force them at build time\n"
+		"  -l|--lba\t\tWrites all source paths and LBA offsets in the XML to force them at build time\n"
 		"  -n|--noxml\t\tDo not generate an XML file and license file\n"
 		"  -r|--raw\t\tDumps all files in raw format (forces --noxml option)\n"
 		"  -S|--sort-by-dir\tOutputs a \"pretty\" XML script where entries are grouped in directories\n"

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -244,7 +244,7 @@ void iso::DirTreeClass::AddDummyEntry(const unsigned int sectors, const unsigned
 	entriesInDir.emplace_back(entries.back());
 }
 
-iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(std::string id, fs::path srcDir, const EntryAttributes& attributes, bool& alreadyExists)
+iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(std::string id, const fs::path& srcDir, const EntryAttributes& attributes, bool& alreadyExists)
 {
 	// Duplicate directory entries are allowed, but the subsequent occurences will not add
 	// a new directory to 'entries'.

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -145,7 +145,7 @@ namespace iso
 		 *
 		 *	Returns: Pointer to another DirTreeClass for accessing the directory record of the subdirectory.
 		 */
-		DirTreeClass* AddSubDirEntry(std::string id, fs::path srcDir, const EntryAttributes& attributes, bool& alreadyExists);
+		DirTreeClass* AddSubDirEntry(std::string id, const fs::path& srcDir, const EntryAttributes& attributes, bool& alreadyExists);
 
 		/**	Writes the source files assigned to the directory entries to a CD image. Its recommended to execute
 		 *	this first before writing the actual file system.

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -581,7 +581,8 @@ int Main(int argc, char* argv[])
 				}
 
 				// Write track information to the CUE sheet
-				if ( const char* trackRelativeSource = trackElement->Attribute(xml::attrib::TRACK_SOURCE); trackRelativeSource == nullptr || *trackRelativeSource == 0 )
+				const char* trackRelativeSource = trackElement->Attribute(xml::attrib::TRACK_SOURCE);
+				if ( trackRelativeSource == nullptr || *trackRelativeSource == 0 )
 				{
 					if ( !global::QuietMode )
 					{
@@ -593,8 +594,7 @@ int Main(int argc, char* argv[])
 
 					return EXIT_FAILURE;
 				}
-				else
-				{
+
 					fs::path trackSource = (global::XMLscript.parent_path() / trackRelativeSource).lexically_normal();
 					if ( cuefp )
 					{
@@ -665,7 +665,6 @@ int Main(int argc, char* argv[])
 					}
 
 					totalLenLBA += audioSize/CD_SECTOR_SIZE;
-				}
 
 				if ( !global::QuietMode )
 				{

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -32,7 +32,7 @@ namespace global
 };
 
 
-bool ParseDirectory(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* parentElement, const fs::path& xmlPath, const EntryAttributes& parentAttribs);
+bool ParseDirectory(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* parentElement, const fs::path& xmlPath, const EntryAttributes& parentAttribs, const fs::path& currentPath);
 int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path& xmlPath, iso::EntryList& entries, iso::IDENTIFIERS& isoIdentifiers, int& totalLen);
 
 bool PackFileAsCDDA(void* buffer, const fs::path& audioFile);
@@ -1202,6 +1202,9 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 		isoIdentifiers.CreationDate = dateBuffer;
 	}
 
+	// Establish default entry attributes from XML (if any)
+	const EntryAttributes defaultAttributes = ReadEntryAttributes(EntryAttributes{}, trackElement->FirstChildElement(xml::elem::DEFAULT_ATTRIBUTES));
+
 	// Parse directory entries in the directory_tree element
 	if ( !global::QuietMode )
 	{
@@ -1220,12 +1223,15 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 		return false;
 	}
 
-	const EntryAttributes defaultAttributes = ReadEntryAttributes(EntryAttributes{}, trackElement->FirstChildElement(xml::elem::DEFAULT_ATTRIBUTES));
+	const char* dirTreePath = directoryTree->Attribute(xml::attrib::ENTRY_SOURCE);
+	fs::path currentPath = dirTreePath != nullptr && *dirTreePath != 0
+		? (xmlPath / dirTreePath).lexically_normal()
+		: xmlPath;
 
 	iso::DIRENTRY& root = iso::DirTreeClass::CreateRootDirectory(entries, volumeDate, ReadEntryAttributes(defaultAttributes, directoryTree));
 	iso::DirTreeClass* dirTree = root.subdir.get();
 
-	if ( !ParseDirectory(dirTree, directoryTree, xmlPath, defaultAttributes) )
+	if ( !ParseDirectory(dirTree, directoryTree, xmlPath, defaultAttributes, currentPath) )
 	{
 		return false;
 	}
@@ -1254,7 +1260,7 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 	return true;
 }
 
-static bool ParseFileEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* dirElement, const fs::path& xmlPath, const EntryAttributes& defaultAttributes)
+static bool ParseFileEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* dirElement, const fs::path& xmlPath, const EntryAttributes& defaultAttributes, const fs::path& currentPath)
 {
 	const char* nameElement = dirElement->Attribute(xml::attrib::ENTRY_NAME);
 	const char* sourceElement = dirElement->Attribute(xml::attrib::ENTRY_SOURCE);
@@ -1290,7 +1296,7 @@ static bool ParseFileEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElemen
 	else
 	{
 		name = nameElement;
-		srcFile = xmlPath / name;
+		srcFile = currentPath / name;
 	}
 
 	{ // ECMA-119 7.5.1 - File Identifier shall contain one dot and uppercase alphanumeric characters or underscores.
@@ -1414,10 +1420,13 @@ static bool ParseFileEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElemen
 			sourceElement = trackElement->Attribute(xml::attrib::TRACK_SOURCE);
 			if(sourceElement == nullptr || *sourceElement == 0)
 			{
-				printf( "ERROR: <%s %s=\"audio\" %s=\"%s\"> must have source\n", xml::elem::TRACK, xml::attrib::TRACK_TYPE, xml::attrib::TRACK_ID, trackid);
-				return false;
+				// Safe cast, the root object is mutable. Casting here to modify the attribute without refactoring the entire call chain.
+				const_cast<tinyxml2::XMLElement*>(trackElement)->SetAttribute(xml::attrib::ENTRY_SOURCE, srcFile.string().c_str());
 			}
-			srcFile = (xmlPath / sourceElement).lexically_normal();
+			else
+			{
+				srcFile = (xmlPath / sourceElement).lexically_normal();
+			}
 		}
 		else
 		{
@@ -1449,7 +1458,7 @@ static bool ParseDummyEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLEleme
 	return true;
 }
 
-static bool ParseDirEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* dirElement, const fs::path& xmlPath, const EntryAttributes& defaultAttributes)
+static bool ParseDirEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* dirElement, const fs::path& xmlPath, const EntryAttributes& defaultAttributes, const fs::path& currentPath)
 {
 	fs::path srcDir;
 	std::string name;
@@ -1461,6 +1470,10 @@ static bool ParseDirEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement
 	if (const char *nameElement = dirElement->Attribute(xml::attrib::ENTRY_NAME); nameElement != nullptr && *nameElement != 0)
 	{
 		name = nameElement;
+		if (srcDir.empty())
+		{
+			srcDir = currentPath / name;
+		}
 	}
 	else if (!srcDir.empty())
 	{
@@ -1518,24 +1531,24 @@ static bool ParseDirEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement
 
 	bool alreadyExists = false;
 	iso::DirTreeClass* subdir = dirTree->AddSubDirEntry(
-		std::move(name), std::move(srcDir), ReadEntryAttributes(defaultAttributes, dirElement), alreadyExists );
+		std::move(name), srcDir, ReadEntryAttributes(defaultAttributes, dirElement), alreadyExists );
 
 	if ( subdir == nullptr )
 	{
 		return false;
 	}
 
-	return ParseDirectory(subdir, dirElement, xmlPath, defaultAttributes);
+	return ParseDirectory(subdir, dirElement, xmlPath, defaultAttributes, srcDir);
 }
 
-bool ParseDirectory(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* parentElement, const fs::path& xmlPath, const EntryAttributes& defaultAttributes)
+bool ParseDirectory(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* parentElement, const fs::path& xmlPath, const EntryAttributes& defaultAttributes, const fs::path& currentPath)
 {
 	for ( const tinyxml2::XMLElement* dirElement = parentElement->FirstChildElement(); dirElement != nullptr; dirElement = dirElement->NextSiblingElement() )
 	{
 		
 		if ( CompareICase( "file", dirElement->Name() ))
 		{
-			if (!ParseFileEntry(dirTree, dirElement, xmlPath, defaultAttributes))
+			if (!ParseFileEntry(dirTree, dirElement, xmlPath, defaultAttributes, currentPath))
 			{
 				return false;
 			}
@@ -1549,7 +1562,7 @@ bool ParseDirectory(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* pare
         }
 		else if ( CompareICase( "dir", dirElement->Name() ))
 		{
-			if (!ParseDirEntry(dirTree, dirElement, xmlPath, defaultAttributes))
+			if (!ParseDirEntry(dirTree, dirElement, xmlPath, defaultAttributes, currentPath))
 			{
 				return false;
 			}

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -284,6 +284,11 @@ int Main(int argc, char* argv[])
 		{
 			tinyxml2::XMLElement *scanElm = toscan.front();
 			toscan.pop();
+			if (const char *srcdir = scanElm->Attribute("srcdir"); srcdir != nullptr && scanElm->Attribute(xml::attrib::ENTRY_SOURCE) == nullptr)
+			{
+				scanElm->SetAttribute(xml::attrib::ENTRY_SOURCE, srcdir);
+				scanElm->DeleteAttribute("srcdir");
+			}
 			if(CompareICase(scanElm->Name(), xml::elem::FILE))
 			{
 				if(scanElm->Attribute(xml::attrib::ENTRY_TYPE, "da"))

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -595,76 +595,76 @@ int Main(int argc, char* argv[])
 					return EXIT_FAILURE;
 				}
 
-					fs::path trackSource = (global::XMLscript.parent_path() / trackRelativeSource).lexically_normal();
-					if ( cuefp )
-					{
-						fprintf( cuefp.get(), "  TRACK %02d AUDIO\n", global::trackNum );
-					}
+				fs::path trackSource = (global::XMLscript.parent_path() / trackRelativeSource).lexically_normal();
+				if ( cuefp )
+				{
+					fprintf( cuefp.get(), "  TRACK %02d AUDIO\n", global::trackNum );
+				}
 
-					// pregap
-					int pregapSectors = 150; // SYSTEM DESCRIPTION CD-ROM XA Ch.II 2.3, pause should be always >= 150 sectors.
-					const tinyxml2::XMLElement *pregapElement = trackElement->FirstChildElement(xml::elem::TRACK_PREGAP);
-					if(pregapElement != nullptr)
+				// pregap
+				int pregapSectors = 150; // SYSTEM DESCRIPTION CD-ROM XA Ch.II 2.3, pause should be always >= 150 sectors.
+				const tinyxml2::XMLElement *pregapElement = trackElement->FirstChildElement(xml::elem::TRACK_PREGAP);
+				if(pregapElement != nullptr)
+				{
+					const char *duration = pregapElement->Attribute(xml::attrib::PREGAP_DURATION);
+					if(duration != nullptr)
 					{
-						const char *duration = pregapElement->Attribute(xml::attrib::PREGAP_DURATION);
-						if(duration != nullptr)
+						pregapSectors = TimecodeToSectors(duration);
+						if(pregapSectors < 0)
 						{
-							pregapSectors = TimecodeToSectors(duration);
-							if(pregapSectors < 0)
-							{
-								printf( "ERROR: %s duration has invalid MM:SS:FF "
-									"for track on line %d.\n", xml::elem::TRACK_PREGAP, pregapElement->GetLineNum() );
-								return EXIT_FAILURE;
-							}
-
-							if(pregapSectors > (80 * 60 * 75) && !global::noWarns)
-							{
-								printf( "WARNING: Duration > 80 minutes\n");
-							}
-						}
-					}
-					if(pregapSectors > 0)
-					{
-						if ( cuefp )
-						{
-							fprintf( cuefp.get(), "    INDEX 00 %s\n", SectorsToTimecode(totalLenLBA).c_str());
-						}
-
-						audioTracks.emplace_back(totalLenLBA, pregapSectors * CD_SECTOR_SIZE);
-						totalLenLBA += pregapSectors;
-					}
-
-					if ( cuefp )
-					{
-						fprintf( cuefp.get(), "    INDEX 01 %s\n", SectorsToTimecode(totalLenLBA).c_str());
-					}
-
-					const unsigned int audioSize = iso::DirTreeClass::GetAudioSize(trackSource);
-					audioTracks.emplace_back(totalLenLBA, audioSize, trackSource.string());
-
-					const char *trackid = trackElement->Attribute(xml::attrib::TRACK_ID);
-					if(trackid != nullptr)
-					{
-						if(!UpdateDAFilesWithLBA(entries, trackid, totalLenLBA))
-						{
+							printf( "ERROR: %s duration has invalid MM:SS:FF "
+								"for track on line %d.\n", xml::elem::TRACK_PREGAP, pregapElement->GetLineNum() );
 							return EXIT_FAILURE;
 						}
-					}
-					else
-					{
-						auto& entry = unrefTracks.emplace_back();
-						entry.id = trackSource.stem().string() + ";1";
-						entry.length = audioSize;
-						entry.lba = totalLenLBA;
-						entry.srcfile = trackSource;
-						entry.type = EntryType::EntryDA;
-						if (!global::QuietMode)
+
+						if(pregapSectors > (80 * 60 * 75) && !global::noWarns)
 						{
-							printf("    DA File \"%s\"\n", trackSource.filename().string().c_str());
+							printf( "WARNING: Duration > 80 minutes\n");
 						}
 					}
+				}
+				if(pregapSectors > 0)
+				{
+					if ( cuefp )
+					{
+						fprintf( cuefp.get(), "    INDEX 00 %s\n", SectorsToTimecode(totalLenLBA).c_str());
+					}
 
-					totalLenLBA += audioSize/CD_SECTOR_SIZE;
+					audioTracks.emplace_back(totalLenLBA, pregapSectors * CD_SECTOR_SIZE);
+					totalLenLBA += pregapSectors;
+				}
+
+				if ( cuefp )
+				{
+					fprintf( cuefp.get(), "    INDEX 01 %s\n", SectorsToTimecode(totalLenLBA).c_str());
+				}
+
+				const unsigned int audioSize = iso::DirTreeClass::GetAudioSize(trackSource);
+				audioTracks.emplace_back(totalLenLBA, audioSize, trackSource.string());
+
+				const char *trackid = trackElement->Attribute(xml::attrib::TRACK_ID);
+				if(trackid != nullptr)
+				{
+					if(!UpdateDAFilesWithLBA(entries, trackid, totalLenLBA))
+					{
+						return EXIT_FAILURE;
+					}
+				}
+				else
+				{
+					auto& entry = unrefTracks.emplace_back();
+					entry.id = trackSource.stem().string() + ";1";
+					entry.length = audioSize;
+					entry.lba = totalLenLBA;
+					entry.srcfile = trackSource;
+					entry.type = EntryType::EntryDA;
+					if (!global::QuietMode)
+					{
+						printf("    DA File \"%s\"\n", trackSource.filename().string().c_str());
+					}
+				}
+
+				totalLenLBA += audioSize/CD_SECTOR_SIZE;
 
 				if ( !global::QuietMode )
 				{


### PR DESCRIPTION
This PR introduces automatic path inference for `mkpsxiso` and updates `dumpsxiso` to generate cleaner XML scripts (explicit `source` fields are now gated behind the `--lba` flag).

**The new path inference logic makes it possible to properly restore support for the legacy `srcdir` element.** Previously, restoring this element wouldn't have been sufficient due to path resolution issues, but the new inference system handles it correctly.

- Fixes #49