### PR TITLE
Support for custom timestamps via XML attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ## Issues
 
-On `ext4` and `xfs` filesystems, the minimum timestamp you can set is 1901/12/13, which makes games that has files/folders with dates older than that (like Crash Bash, Spyro3, Vagrant Story, etc) impossible to be rebuilt 1:1. A workaround to this is to work on a fs that has better date support, like `f2fs` `ntfs` `btrfs`.
+On `ext4` and `xfs` filesystems, if there is no XML `date` attribute, the minimum supported date is 1901/12/13. This makes games that have files/folders with dates older than that (like Crash Bash, Spyro3, Vagrant Story, etc.) impossible to rebuild 1:1. A workaround is to work on a fs that has better date support, like `f2fs`, `ntfs` or `btrfs`.
 
 The other known major issue that hasn't (or cannot) be resolved is that if you create a disc image with the following directory structure:
 

--- a/examples/example.xml
+++ b/examples/example.xml
@@ -32,6 +32,7 @@
 						  If new_type is not specified, defaults to 'false'.
 			ps2			- Optional, for data track only, specifies if the image is a Playstation 2 one. Defaults to 'false'.
 			source		- For audio tracks only, specifies the file name of a wav audio file as source data for the audio track.
+			trackid		- For audio tracks only, links the track to a 'da' type file. More details below.
 	-->
 	<track type="data" xa_edc="true" new_type="false">
 	
@@ -100,6 +101,8 @@
 										 'xa' and 'str' can also be used as aliases for 'mixed'.
 								'da': is for CD-DA audio files. More details below.
 							  If no value for type is specified, the default is 'data'.
+					trackid - For 'da' type files only, links the file to an audio track. More details below.
+					date	- Optional, custom file timestamp. Format is YYYYMMDDHHMMSS.
 					hidden	- Optional, flag to set files/directories as "hidden". Options are
 								'0': not hidden. (Default)
 								'1': hidden.
@@ -126,6 +129,7 @@
 					name	- Specifies the name of the subdirectory.
 					source	- Specifies the directory path to the source files if no source attribute is
 							  specified to the <file> elements (optional, can be a relative or absolute path).
+					date	- Optional, custom file timestamp. Format is YYYYMMDDHHMMSS.
 					hidden	- Optional, flag to set files/directories as "hidden" (see above for description).
 					order	- Optional, custom Directory Record order (see above for description).
 						  

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -908,6 +908,7 @@ tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry, tinyx
 				const fs::path outputPath = sourcePath / entry.virtualPath / CleanIdentifier(entry.identifier);
 				newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, outputPath.generic_string().c_str());
 			}
+			newelement->SetAttribute(xml::attrib::ENTRY_DATE, DateToString(entry.entry.entryDate, false).c_str());
 		}
 		else
 		{
@@ -936,13 +937,14 @@ tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry, tinyx
 				const fs::path outputPath = sourcePath / entry.virtualPath / CleanIdentifier(entry.identifier);
 				newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, outputPath.generic_string().c_str());
 			}
-			newelement->SetAttribute(xml::attrib::ENTRY_TYPE, entry.type == EntryType::EntryFile ? "data" : "mixed");	
+			newelement->SetAttribute(xml::attrib::ENTRY_TYPE, entry.type == EntryType::EntryFile ? "data" : "mixed");
 		}
 		else
 		{
 			newelement->SetAttribute(xml::attrib::TRACK_ID, entry.trackid.c_str());
 			newelement->SetAttribute(xml::attrib::ENTRY_TYPE, "da");
 		}
+		newelement->SetAttribute(xml::attrib::ENTRY_DATE, DateToString(entry.entry.entryDate, false).c_str());
 	}
 	WriteOptionalXMLAttribs(newelement, entry, entry.type, attributeCounters);
 	return dirElement;

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -1032,8 +1032,8 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 	CopyStringPadWithSpaces( isoDescriptor.abstractFileIdentifier, nullptr );
 	CopyStringPadWithSpaces( isoDescriptor.bibliographicFilelIdentifier, nullptr );
 
-	isoDescriptor.volumeCreateDate = GetLongDateFromString(id.CreationDate);
-	isoDescriptor.volumeModifyDate = GetLongDateFromString(id.ModificationDate);
+	ParseLongDateFromString( isoDescriptor.volumeCreateDate, id.CreationDate );
+	ParseLongDateFromString( isoDescriptor.volumeModifyDate, id.ModificationDate );
 	isoDescriptor.volumeEffectiveDate = isoDescriptor.volumeExpiryDate = GetUnspecifiedLongDate();
 	isoDescriptor.fileStructVersion = 1;
 

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -22,8 +22,12 @@ static const int RoundToEven(const int val)
 	return (val + 1) & -2;
 }
 
-static cd::ISO_DATESTAMP GetISODateStamp(time_t time, signed char GMToffs)
+static cd::ISO_DATESTAMP GetISODateStamp(time_t time, signed char GMToffs, const char* date)
 {
+	cd::ISO_DATESTAMP result;
+	if (ParseDateFromString(result, date, GMToffs))
+		return result;
+
 	tm* timestamp;
 	if (global::new_type.has_value()) {
 		timestamp = CustomLocalTime(&time);
@@ -35,7 +39,6 @@ static cd::ISO_DATESTAMP GetISODateStamp(time_t time, signed char GMToffs)
 		timestamp = gmtime( &time );
 	}
 
-	cd::ISO_DATESTAMP result{.month = 1, .day = 1, .GMToffs = GMToffs};
 	if (timestamp != nullptr)
 	{
 		result.year		= timestamp->tm_year;
@@ -107,7 +110,7 @@ iso::DIRENTRY& iso::DirTreeClass::CreateRootDirectory(EntryList& entries, const 
 	return entries.back();
 }
 
-bool iso::DirTreeClass::AddFileEntry(std::string id, EntryType type, fs::path srcfile, const EntryAttributes& attributes, const char *trackid)
+bool iso::DirTreeClass::AddFileEntry(std::string id, EntryType type, fs::path srcfile, const EntryAttributes& attributes, const char *trackid, const char* date)
 {
 	auto fileAttrib = Stat(srcfile);
     if ( !fileAttrib )
@@ -208,6 +211,7 @@ bool iso::DirTreeClass::AddFileEntry(std::string id, EntryType type, fs::path sr
 	entry.order		= attributes.ORDER;
 	entry.flba		= attributes.FLBA;
 	entry.srcfile	= std::move(srcfile);
+	entry.date		= GetISODateStamp( fileAttrib->st_mtime, attributes.GMTOffs, date );
 
 	if ( type == EntryType::EntryDA )
 	{
@@ -218,8 +222,6 @@ bool iso::DirTreeClass::AddFileEntry(std::string id, EntryType type, fs::path sr
 	{
 		entry.length = fileAttrib->st_size;
 	}
-
-    entry.date = GetISODateStamp( fileAttrib->st_mtime, attributes.GMTOffs );
 
 	entries.emplace_back(std::move(entry));
 	entriesInDir.emplace_back(entries.back());
@@ -244,7 +246,7 @@ void iso::DirTreeClass::AddDummyEntry(const unsigned int sectors, const unsigned
 	entriesInDir.emplace_back(entries.back());
 }
 
-iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(std::string id, const fs::path& srcDir, const EntryAttributes& attributes, bool& alreadyExists)
+iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(std::string id, const fs::path& srcDir, const EntryAttributes& attributes, bool& alreadyExists, const char* date)
 {
 	// Duplicate directory entries are allowed, but the subsequent occurences will not add
 	// a new directory to 'entries'.
@@ -288,7 +290,7 @@ iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(std::string id, const fs::p
 	entry.UID		= attributes.UID;
 	entry.order		= attributes.ORDER;
 	entry.flba		= attributes.FLBA;
-	entry.date		= GetISODateStamp( fileAttrib->st_mtime, attributes.GMTOffs );
+	entry.date		= GetISODateStamp( fileAttrib->st_mtime, attributes.GMTOffs, date );
 	entry.length	= 0; // Length is meaningless for directories
 
 	entries.emplace_back(std::move(entry));

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -115,7 +115,7 @@ namespace iso
 		 *	*srcfile	- Path and filename to the source file.
 		 *  attributes  - GMT offset/XA permissions for the file, if applicable.
 		 */
-		bool AddFileEntry(std::string id, EntryType type, fs::path srcfile, const EntryAttributes& attributes, const char *trackid = nullptr);
+		bool AddFileEntry(std::string id, EntryType type, fs::path srcfile, const EntryAttributes& attributes, const char *trackid, const char* date);
 
 		/** Adds an invisible dummy file entry to the directory record. Its invisible because its file entry
 		 *	is not actually added to the directory record.
@@ -145,7 +145,7 @@ namespace iso
 		 *
 		 *	Returns: Pointer to another DirTreeClass for accessing the directory record of the subdirectory.
 		 */
-		DirTreeClass* AddSubDirEntry(std::string id, const fs::path& srcDir, const EntryAttributes& attributes, bool& alreadyExists);
+		DirTreeClass* AddSubDirEntry(std::string id, const fs::path& srcDir, const EntryAttributes& attributes, bool& alreadyExists, const char* date);
 
 		/**	Writes the source files assigned to the directory entries to a CD image. Its recommended to execute
 		 *	this first before writing the actual file system.

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -1433,7 +1433,7 @@ static bool ParseFileEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElemen
 		}
 	}
 
-	return dirTree->AddFileEntry(std::move(name), entry, std::move(srcFile), ReadEntryAttributes(defaultAttributes, dirElement), trackid);
+	return dirTree->AddFileEntry(std::move(name), entry, std::move(srcFile), ReadEntryAttributes(defaultAttributes, dirElement), trackid, dirElement->Attribute(xml::attrib::ENTRY_DATE));
 }
 
 static bool ParseDummyEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* dirElement)
@@ -1521,7 +1521,7 @@ static bool ParseDirEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement
 
 	bool alreadyExists = false;
 	iso::DirTreeClass* subdir = dirTree->AddSubDirEntry(
-		std::move(name), srcDir, ReadEntryAttributes(defaultAttributes, dirElement), alreadyExists );
+		std::move(name), srcDir, ReadEntryAttributes(defaultAttributes, dirElement), alreadyExists, dirElement->Attribute(xml::attrib::ENTRY_DATE) );
 
 	if ( subdir == nullptr )
 	{

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -1188,12 +1188,8 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 		volumeDate.GMToffs = static_cast<signed char>(-SYSTEM_TIMEZONE / 60 / 15); // Seconds to 15-minute units
 
 		// Convert ISO_DATESTAMP to ISO_LONG_DATESTAMP char*
-		static char dateBuffer[20];
-		snprintf(dateBuffer, sizeof(dateBuffer), "%04u%02hhu%02hhu%02hhu%02hhu%02hhu00%+hhd",
-				volumeDate.year + 1900, volumeDate.month, volumeDate.day,
-				volumeDate.hour, volumeDate.minute, volumeDate.second, volumeDate.GMToffs);
-
-		isoIdentifiers.CreationDate = dateBuffer;
+		static const std::string creationDate = DateToString(volumeDate, true);
+		isoIdentifiers.CreationDate = creationDate.c_str();
 	}
 
 	// Establish default entry attributes from XML (if any)

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -1173,14 +1173,8 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 
 	// Establish the volume timestamp to either the current local time or isoIdentifiers.CreationDate (if specified)
 	cd::ISO_DATESTAMP volumeDate;
-	bool gotDateFromXML = false;
-	if ( isoIdentifiers.CreationDate != nullptr )
-	{
-		// Try to use time from XML. If it's malformed, fall back to local time.
-		volumeDate = GetDateFromString(isoIdentifiers.CreationDate, &gotDateFromXML);
-	}
-
-	if ( !gotDateFromXML )
+	// Try to use time from XML. If it's malformed, fall back to local time.
+	if ( !ParseDateFromString(volumeDate, isoIdentifiers.CreationDate) )
 	{
 		// Use local time
 		const tm imageTime = *localtime( &global::BuildTime );

--- a/src/shared/common.cpp
+++ b/src/shared/common.cpp
@@ -31,49 +31,43 @@ ISO_DATESTAMP GetDateFromString(const char* str, bool* success)
 	return result;
 }
 
-ISO_LONG_DATESTAMP GetLongDateFromString(const char* str)
+bool ParseLongDateFromString(ISO_LONG_DATESTAMP& result, const char* str, char defaultGMT)
 {
-	ISO_LONG_DATESTAMP result {};
+	if (!str || strlen(str) < 14)
+	{
+		result = GetUnspecifiedLongDate();
+		return false;
+	}
 
-	if (str) {
-		unsigned int year, month, day, hour, minute, second, hsecond {};
-
-		const int argsRead = sscanf( str, "%4u%2u%2u%2u%2u%2u%2u%hhd",
-			&year, &month, &day, &hour, &minute, &second, &hsecond, &result.GMToffs );
-
-		if (argsRead >= 6) {
-			if (argsRead < 8) {
-				// Consider GMToffs optional
-				result.GMToffs = 36;
-			}
-
-			auto intToChars = [](unsigned int value, char* dest, unsigned int size) {
-				for (int i = size - 1; i >= 0; --i) {
-					dest[i] = '0' + (value % 10);
-					value /= 10;
-				}
-			};
-
-			intToChars(year, result.year, 4);
-			intToChars(month, result.month, 2);
-			intToChars(day, result.day, 2);
-			intToChars(hour, result.hour, 2);
-			intToChars(minute, result.minute, 2);
-			intToChars(second, result.second, 2);
-			intToChars(hsecond, result.hsecond, 2);
-
-			return result;
+	for (int i = 0; i < 14; ++i)
+	{
+		if (!isdigit((unsigned char)str[i]))
+		{
+			result = GetUnspecifiedLongDate();
+			return false;
 		}
 	}
 
-	return GetUnspecifiedLongDate();
+	if (isdigit((unsigned char)str[14]) && isdigit((unsigned char)str[15]))
+	{
+		memcpy(&result, str, 16);
+		result.GMToffs = str[16] != 0 ? (char)atoi(str + 16) : defaultGMT;
+	}
+	else
+	{
+		memcpy(&result, str, 14);
+		memcpy(result.hsecond, "00", 2);
+		result.GMToffs = str[14] != 0 && (str[14] == '+' || str[14] == '-') ? (char)atoi(str + 14) : defaultGMT;
+	}
+
+	return true;
 }
 
 ISO_LONG_DATESTAMP GetUnspecifiedLongDate()
 {
 	ISO_LONG_DATESTAMP result;
 
-	memset(&result, '0', sizeof(result));
+	memset(&result, '0', sizeof(result) - 1);
 	result.GMToffs = 0;
 
 	return result;

--- a/src/shared/common.cpp
+++ b/src/shared/common.cpp
@@ -3,14 +3,16 @@
 
 using namespace cd;
 
-ISO_DATESTAMP GetDateFromString(const char* str, bool* success)
+bool ParseDateFromString(ISO_DATESTAMP& result, const char* str, char defaultGMT)
 {
-	bool succeeded = false;
-
-	ISO_DATESTAMP result {};
+	if (str == nullptr || strlen(str) < 14)
+	{
+		result = {.month = 1, .day = 1, .GMToffs = defaultGMT};
+		return false;
+	}
 
 	unsigned int year;
-	const int argsRead = sscanf( str, "%4u%2hhu%2hhu%2hhu%2hhu%2hhu%*2u%hhd",
+	const int argsRead = sscanf( str, "%4u%2hhu%2hhu%2hhu%2hhu%2hhu%*2[0-9]%hhd",
 		&year, &result.month, &result.day,
 		&result.hour, &result.minute, &result.second, &result.GMToffs );
 	if (argsRead >= 6)
@@ -19,16 +21,13 @@ ISO_DATESTAMP GetDateFromString(const char* str, bool* success)
 		if (argsRead < 7)
 		{
 			// Consider GMToffs optional
-			result.GMToffs = 36;
+			result.GMToffs = defaultGMT;
 		}
-		succeeded = true;
+		return true;
 	}
 
-	if (success != nullptr)
-	{
-		*success = succeeded;
-	}
-	return result;
+	result = {.month = 1, .day = 1, .GMToffs = defaultGMT};
+	return false;
 }
 
 bool ParseLongDateFromString(ISO_LONG_DATESTAMP& result, const char* str, char defaultGMT)

--- a/src/shared/common.cpp
+++ b/src/shared/common.cpp
@@ -72,6 +72,20 @@ ISO_LONG_DATESTAMP GetUnspecifiedLongDate()
 	return result;
 }
 
+std::string DateToString(const cd::ISO_DATESTAMP& src, bool ext)
+{
+	char buf[20];
+	snprintf(buf, sizeof(buf), "%04u%02hhu%02hhu%02hhu%02hhu%02hhu",
+		src.year + 1900u, src.month, src.day, src.hour, src.minute, src.second);
+
+	if (ext)
+	{
+		snprintf(buf + 14, 6, "00%+hhd", src.GMToffs);
+	}
+
+	return std::string(buf);
+}
+
 std::string LongDateToString(const cd::ISO_LONG_DATESTAMP& src)
 {
 	// Interpret ISO_LONG_DATESTAMP as 16 characters, manually write out GMT offset

--- a/src/shared/common.h
+++ b/src/shared/common.h
@@ -59,6 +59,7 @@ namespace global
 bool ParseDateFromString(cd::ISO_DATESTAMP& result, const char* str, char defaultGMT = 36);
 bool ParseLongDateFromString(cd::ISO_LONG_DATESTAMP& result, const char* str, char defaultGMT = 36);
 cd::ISO_LONG_DATESTAMP GetUnspecifiedLongDate();
+std::string DateToString(const cd::ISO_DATESTAMP& src, bool ext);
 std::string LongDateToString(const cd::ISO_LONG_DATESTAMP& src);
 
 // Helper functions for sector conversion

--- a/src/shared/common.h
+++ b/src/shared/common.h
@@ -56,7 +56,7 @@ namespace global
 }
 
 // Helper functions for datestamp manipulation
-cd::ISO_DATESTAMP GetDateFromString(const char* str, bool* success = nullptr);
+bool ParseDateFromString(cd::ISO_DATESTAMP& result, const char* str, char defaultGMT = 36);
 bool ParseLongDateFromString(cd::ISO_LONG_DATESTAMP& result, const char* str, char defaultGMT = 36);
 cd::ISO_LONG_DATESTAMP GetUnspecifiedLongDate();
 std::string LongDateToString(const cd::ISO_LONG_DATESTAMP& src);

--- a/src/shared/common.h
+++ b/src/shared/common.h
@@ -57,7 +57,7 @@ namespace global
 
 // Helper functions for datestamp manipulation
 cd::ISO_DATESTAMP GetDateFromString(const char* str, bool* success = nullptr);
-cd::ISO_LONG_DATESTAMP GetLongDateFromString(const char* str);
+bool ParseLongDateFromString(cd::ISO_LONG_DATESTAMP& result, const char* str, char defaultGMT = 36);
 cd::ISO_LONG_DATESTAMP GetUnspecifiedLongDate();
 std::string LongDateToString(const cd::ISO_LONG_DATESTAMP& src);
 

--- a/src/shared/xml.h
+++ b/src/shared/xml.h
@@ -35,6 +35,7 @@ namespace attrib
 	constexpr const char* ENTRY_NAME = "name";
 	constexpr const char* ENTRY_SOURCE = "source";
 	constexpr const char* ENTRY_TYPE = "type";
+	constexpr const char* ENTRY_DATE = "date";
 	constexpr const char* ORDER = "order";
 	constexpr const char* OFFSET = "offs";
 


### PR DESCRIPTION
This PR introduces a `date` attribute to the XML schema, to preserve timestamps independently of the source files.

Previously, modifying a file would change its timestamp in the generated ISO. This caused xdelta patches to grow unnecessarily because the filesystem metadata changed even if the file content change was minimal.
By allowing fixed dates in the XML, this feature simulates a "file injection" behavior, keeping timestamps consistent and ensuring that binary patches only reflect actual data changes.

Additionally, this bypasses the filesystem limitations on `ext4` and `xfs`, where dates older than December 1901 could not be represented correctly.

This PR depends on:
- #71