### PR TITLE
Rename `new_type` attribute and code improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
   build-linux:
     name:    Build mkpsxiso on Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Fetch repo contents
@@ -39,8 +39,6 @@ jobs:
 
     - name: Build and package mkpsxiso
       run: |
-        export CC=clang
-        export CXX=clang++
         cmake --workflow ci
 
     - name: Upload build artifacts
@@ -54,6 +52,9 @@ jobs:
   build-macos:
     name:    Build mkpsxiso on macOS
     runs-on: macos-latest
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CMAKE_OSX_ARCHITECTURES:  "x86_64;arm64"
 
     steps:
     - name: Fetch repo contents

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,12 @@ project(
 	HOMEPAGE_URL "https://github.com/Lameguy64/mkpsxiso"
 )
 
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-set(CMAKE_CXX_STANDARD         20)
+set(CMAKE_CXX_STANDARD			20)
+set(CMAKE_CXX_STANDARD_REQUIRED	ON)
+set(CMAKE_CXX_EXTENSIONS		OFF)
+
+set(BUILD_SHARED_LIBS			OFF)
+set(CMAKE_MSVC_RUNTIME_LIBRARY	"MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 # Useful paths
 set(mkpsxiso_dir "src/mkpsxiso")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,13 @@ cmake_minimum_required(VERSION 3.25)
 
 project(
 	mkpsxiso
-	LANGUAGES    C CXX
+	LANGUAGES    CXX
 	VERSION      2.20
 	DESCRIPTION  "PlayStation ISO image maker & dumping tool"
 	HOMEPAGE_URL "https://github.com/Lameguy64/mkpsxiso"
 )
 
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-set(CMAKE_C_STANDARD           11)
 set(CMAKE_CXX_STANDARD         20)
 
 # Useful paths

--- a/examples/example.xml
+++ b/examples/example.xml
@@ -28,13 +28,13 @@
 			type		- Track type (either data or audio).
 			xa_edc		- For data track only, specifies if the image has (true) or no (false) EDC in Form 2 sectors.
 						  If xa_edc is not specified, defaults to 'true'.
-			new_type	- For data track only, specifies if the image was created with the old(<2003) Sony's mastering tool.
-						  If new_type is not specified, defaults to 'false'.
+			cdvd_style	- For data track only, specifies if the image follows Sony CD/DVD-ROM Generator style.
+						  If cdvd_style is not specified, defaults to 'false'.
 			ps2			- Optional, for data track only, specifies if the image is a Playstation 2 one. Defaults to 'false'.
 			source		- For audio tracks only, specifies the file name of a wav audio file as source data for the audio track.
 			trackid		- For audio tracks only, links the track to a 'da' type file. More details below.
 	-->
-	<track type="data" xa_edc="true" new_type="false">
+	<track type="data" xa_edc="true" cdvd_style="false">
 	
 		<!-- <identifiers>
 			Optional, Specifies the identifier strings for the data track.
@@ -108,7 +108,7 @@
 								'1': hidden.
 								'2': obfuscated. (Doesn't add the entry to the Directory Record)
 								'3': obfuscated and hidden. (Only for directories)
-					order	- Optional, custom Directory Record order for games with the 'new_type' string on 'true'.
+					order	- Optional, custom Directory Record order for games with the 'cdvd_style' string on 'true'.
 							  This setting doesn't modify the LBA and is per directory. If order is not specified, defaults to '0'.
 							  So, files/folders with order < 0 will be before the unordered ones and after them the ones with order > 0.
 				

--- a/src/dumpsxiso/cdreader.cpp
+++ b/src/dumpsxiso/cdreader.cpp
@@ -49,30 +49,26 @@ inline bool cd::IsoReader::ReadSector()
 
 inline size_t cd::IsoReader::ReadBytesImpl(void* ptr, size_t bytes, const bool singleSector, const size_t dataBeg, const size_t dataEnd)
 {
-	if (currentSector >= totalSectors)
-	{
-		if (ptr)
-		{
-			memset(ptr, 0, bytes);
-		}
-		return 0;
-	}
-
 	size_t bytesRead = 0;
     char* const dataPtr = (char*)ptr;
 
+	if (currentSector >= totalSectors) [[unlikely]]
+		goto eof_fill;
+
     while(bytes > 0)
 	{
-		if (currentByte < dataEnd)
-		{
-			if (currentByte < dataBeg)
-			{
-				currentByte = dataBeg;
-			}
+		if (currentByte >= dataEnd) [[unlikely]]
+			goto check_next_sector;
 
+		if (currentByte < dataBeg)
+		{
+			currentByte = dataBeg;
+		}
+
+		{
 			const size_t toRead = std::min(dataEnd - currentByte, bytes);
 
-			if (ptr)
+			if (dataPtr != nullptr)
 			{
 				memcpy(dataPtr + bytesRead, &sectorBuff[currentByte], toRead);
 			}
@@ -84,13 +80,21 @@ inline size_t cd::IsoReader::ReadBytesImpl(void* ptr, size_t bytes, const bool s
 
 		if (currentByte >= dataEnd)
 		{
-			if (singleSector || !PrepareNextSector())
-			{
+		check_next_sector:
+			if (singleSector)
 				return bytesRead;
-			}
+			else if (!PrepareNextSector()) [[unlikely]]
+				goto eof_fill;
 		}
     }
 
+	return bytesRead;
+
+eof_fill:
+	if (dataPtr != nullptr && bytes > 0)
+	{
+		memset(dataPtr + bytesRead, 0, bytes);
+	}
     return bytesRead;
 }
 
@@ -328,7 +332,7 @@ void cd::IsoDirEntries::ReadDirEntries(cd::IsoReader* reader, int lba, int secto
 	}
 }
 
-std::optional<cd::IsoDirEntries::Entry> cd::IsoDirEntries::ReadEntry(cd::IsoReader* reader) const
+std::optional<cd::IsoDirEntries::Entry> cd::IsoDirEntries::ReadEntry(cd::IsoReader* reader)
 {
 	Entry entry;
 

--- a/src/dumpsxiso/cdreader.cpp
+++ b/src/dumpsxiso/cdreader.cpp
@@ -307,7 +307,7 @@ void cd::IsoDirEntries::ReadDirEntries(cd::IsoReader* reader, int lba, int secto
 
 			if (numEntries++ >= 2)
 			{
-				if (*global::new_type)
+				if (*global::cdvd_style)
 				{
 					entry->order = order++;
 				}
@@ -323,7 +323,7 @@ void cd::IsoDirEntries::ReadDirEntries(cd::IsoReader* reader, int lba, int secto
 		});
 
 	// Delete orders if all are correct to avoid populate the xml with unnecessary strings
-	if (*global::new_type)
+	if (*global::cdvd_style)
 	{
 		auto& entriesInDir = dirEntryList.GetView();
 		for (int index = 0; index < entriesInDir.size(); index++)

--- a/src/dumpsxiso/cdreader.cpp
+++ b/src/dumpsxiso/cdreader.cpp
@@ -305,7 +305,7 @@ void cd::IsoDirEntries::ReadDirEntries(cd::IsoReader* reader, int lba, int secto
 				{
 					entry->order = order++;
 				}
-				dirEntryList.emplace(std::move(entry.value()));
+				dirEntryList.emplace(std::move(*entry));
 			}
 		}
     }
@@ -392,6 +392,6 @@ void cd::IsoDirEntries::ReadRootDir(cd::IsoReader* reader, int lba)
 	auto entry = ReadEntry(reader);
 	if (entry)
 	{
-		dirEntryList.emplace(std::move(entry.value()));
+		dirEntryList.emplace(std::move(*entry));
 	}
 }

--- a/src/dumpsxiso/cdreader.cpp
+++ b/src/dumpsxiso/cdreader.cpp
@@ -7,11 +7,8 @@ cd::IsoReader::IsoReader()
 
 cd::IsoReader::~IsoReader()
 {
-    if (filePtr != NULL)
-		fclose(filePtr);
-
+	Close();
 }
-
 
 bool cd::IsoReader::Open(const fs::path& fileName)
 {
@@ -22,11 +19,10 @@ bool cd::IsoReader::Open(const fs::path& fileName)
     if (filePtr == NULL)
 		return(false);
 
-	fseek(filePtr, 0, SEEK_END);
-	totalSectors = ftell(filePtr) / CD_SECTOR_SIZE;
-	fseek(filePtr, 0, SEEK_SET);
+	totalSectors = GetSize(fileName) / CD_SECTOR_SIZE;
 
-    if (fread(sectorBuff, CD_SECTOR_SIZE, 1, filePtr) != 1) {
+	if (!ReadSector())
+	{
 		Close();
 		return false;
 	}
@@ -34,11 +30,21 @@ bool cd::IsoReader::Open(const fs::path& fileName)
     currentByte		= 0;
     currentSector	= 0;
 
-    sectorM2F1 = (cd::SECTOR_M2F1*)sectorBuff;
-    sectorM2F2 = (cd::SECTOR_M2F2*)sectorBuff;
-
 	return(true);
 
+}
+
+inline bool cd::IsoReader::ReadSector()
+{
+	if (fread(sectorBuff, CD_SECTOR_SIZE, 1, filePtr) != 1)
+	{
+		return false;
+	}
+
+	sectorM2F1 = reinterpret_cast<cd::SECTOR_M2F1*>(sectorBuff);
+	sectorM2F2 = reinterpret_cast<cd::SECTOR_M2F2*>(sectorBuff);
+
+	return true;
 }
 
 inline size_t cd::IsoReader::ReadBytesImpl(void* ptr, size_t bytes, const bool singleSector, const size_t dataBeg, const size_t dataEnd)
@@ -111,43 +117,33 @@ size_t cd::IsoReader::SkipBytes(size_t bytes, bool singleSector)
 	return ReadBytesImpl(nullptr, bytes, singleSector, DATA_BEG, DATA_BEG + F1_DATA_SIZE);
 }
 
-bool cd::IsoReader::SeekToSector(int sector) {
-
+bool cd::IsoReader::SeekToSector(const uint32_t sector)
+{
 	if (sector >= totalSectors || filePtr == nullptr)
 		return false;
 
-    fseek(filePtr, CD_SECTOR_SIZE*sector, SEEK_SET);
-	if (fread(sectorBuff, CD_SECTOR_SIZE, 1, filePtr) != 1) {
+    if (SeekFile(filePtr, CD_SECTOR_SIZE*static_cast<int64_t>(sector), SEEK_SET) != 0 ||
+		!ReadSector())
+	{
 		return false;
 	}
 
 	currentSector = sector;
 	currentByte = 0;
 
-	sectorM2F1 = (cd::SECTOR_M2F1*)sectorBuff;
-    sectorM2F2 = (cd::SECTOR_M2F2*)sectorBuff;
-
-	return !ferror(filePtr);
-
+	return true;
 }
 
-size_t cd::IsoReader::SeekToByte(size_t offs) {
-
-	int sector = (offs/CD_SECTOR_SIZE);
-
-	fseek(filePtr, CD_SECTOR_SIZE*sector, SEEK_SET);
-    if (fread(sectorBuff, CD_SECTOR_SIZE, 1, filePtr) != 1) {
-		return 0;
+bool cd::IsoReader::SeekToByte(const size_t offs)
+{
+	if (!SeekToSector(offs/CD_SECTOR_SIZE))
+	{
+		return false;
 	}
 
-	currentSector = sector;
 	currentByte = offs%CD_SECTOR_SIZE;
 
-	sectorM2F1 = (cd::SECTOR_M2F1*)sectorBuff;
-    sectorM2F2 = (cd::SECTOR_M2F2*)sectorBuff;
-
-	return (CD_SECTOR_SIZE*static_cast<size_t>(currentSector))+currentByte;
-
+	return true;
 }
 
 size_t cd::IsoReader::GetPos() const
@@ -169,13 +165,11 @@ bool cd::IsoReader::PrepareNextSector()
 	currentByte = 0;
 	currentSector++;
 
-    if (fread(sectorBuff, CD_SECTOR_SIZE, 1, filePtr) != 1)
+	if (!ReadSector())
 	{
 		return false;
-    }
+	}
 
-    sectorM2F1 = (cd::SECTOR_M2F1*)sectorBuff;
-	sectorM2F2 = (cd::SECTOR_M2F2*)sectorBuff;
 	return true;
 }
 

--- a/src/dumpsxiso/cdreader.cpp
+++ b/src/dumpsxiso/cdreader.cpp
@@ -269,13 +269,9 @@ static EntryType GetXAEntryType(unsigned short xa_attr)
 		// if the mode 2 form 1 flag is set, and form 2 is not, we assume this is a regular file.
 		return EntryType::EntryFile;
 	}
-	if ( (xa_attr & 0x10) && !(xa_attr & 0x08) )
-	{
-		// if the mode 2 form 2 flag is set, and form 1 is not, we assume this is a pure audio xa file.
-		return EntryType::EntryXA;
-	}
 
-	// here all flags are set to the same value. From what I could see until now, when both flags are the same,
+	// If the mode 2 form 2 flag (0x10) is set, and form 1 (0x08) is not, we assume this is a pure audio xa file.
+	// Otherwise, all flags are set to the same value. From what I could see until now, when both flags are the same,
 	// this is interpreted in the following two ways, which both lead us to choose str/xa type.
 	// 1. Both values are 1, which means there is an indication by the mode 2 form 2 flag that the data is not
 	//    regular mode 2 form 1 data (i.e., it is either mixed or just xa).

--- a/src/dumpsxiso/cdreader.cpp
+++ b/src/dumpsxiso/cdreader.cpp
@@ -41,9 +41,14 @@ bool cd::IsoReader::Open(const fs::path& fileName)
 
 }
 
-size_t cd::IsoReader::ReadBytes(void* ptr, size_t bytes, bool singleSector)
+inline size_t cd::IsoReader::ReadBytesImpl(void* ptr, size_t bytes, const bool singleSector, const size_t dataBeg, const size_t dataEnd)
 {
-	if (currentSector >= totalSectors) {
+	if (currentSector >= totalSectors)
+	{
+		if (ptr)
+		{
+			memset(ptr, 0, bytes);
+		}
 		return 0;
 	}
 
@@ -52,15 +57,26 @@ size_t cd::IsoReader::ReadBytes(void* ptr, size_t bytes, bool singleSector)
 
     while(bytes > 0)
 	{
-		const size_t toRead = std::min(F1_DATA_SIZE - currentByte, bytes);
+		if (currentByte < dataEnd)
+		{
+			if (currentByte < dataBeg)
+			{
+				currentByte = dataBeg;
+			}
 
-        memcpy(dataPtr+bytesRead, &sectorM2F1->data[currentByte], toRead);
+			const size_t toRead = std::min(dataEnd - currentByte, bytes);
 
-		currentByte += toRead;
-		bytesRead += toRead;
-		bytes -= toRead;
+			if (ptr)
+			{
+				memcpy(dataPtr + bytesRead, &sectorBuff[currentByte], toRead);
+			}
 
-		if (currentByte >= F1_DATA_SIZE)
+			bytes		-= toRead;
+			bytesRead	+= toRead;
+			currentByte	+= toRead;
+		}
+
+		if (currentByte >= dataEnd)
 		{
 			if (singleSector || !PrepareNextSector())
 			{
@@ -70,98 +86,29 @@ size_t cd::IsoReader::ReadBytes(void* ptr, size_t bytes, bool singleSector)
     }
 
     return bytesRead;
+}
 
+size_t cd::IsoReader::ReadBytes(void* ptr, size_t bytes, bool singleSector)
+{
+	constexpr size_t DATA_BEG = offsetof(cd::SECTOR_M2F1, data);
+	return ReadBytesImpl(ptr, bytes, singleSector, DATA_BEG, DATA_BEG + F1_DATA_SIZE);
 }
 
 size_t cd::IsoReader::ReadBytesXA(void* ptr, size_t bytes, bool singleSector)
 {
-	if (currentSector >= totalSectors) {
-		return 0;
-	}
-
-	size_t bytesRead = 0;
-    char* const dataPtr = (char*)ptr;
-
-    while(bytes > 0)
-	{
-		const size_t toRead = std::min(XA_DATA_SIZE - currentByte, bytes);
-
-        memcpy(dataPtr+bytesRead, &sectorM2F2->subHead[currentByte], toRead);
-
-		currentByte += toRead;
-		bytesRead += toRead;
-		bytes -= toRead;
-
-		if (currentByte >= XA_DATA_SIZE)
-		{
-			if (singleSector || !PrepareNextSector())
-			{
-				return bytesRead;
-			}
-		}
-    }
-
-    return bytesRead;
-
+	constexpr size_t DATA_BEG = offsetof(cd::SECTOR_M2F2, subHead);
+	return ReadBytesImpl(ptr, bytes, singleSector, DATA_BEG, DATA_BEG + XA_DATA_SIZE);
 }
 
 size_t cd::IsoReader::ReadBytesDA(void* ptr, size_t bytes, bool singleSector)
 {
-	if (currentSector >= totalSectors) {
-		return 0;
-	}
-
-	size_t bytesRead = 0;
-    char* const dataPtr = (char*)ptr;
-
-    while(bytes > 0)
-	{
-		const size_t toRead = std::min(CD_SECTOR_SIZE - currentByte, bytes);
-
-        memcpy(dataPtr+bytesRead, &sectorBuff[currentByte], toRead);
-
-		currentByte += toRead;
-		bytesRead += toRead;
-		bytes -= toRead;
-
-		if (currentByte >= CD_SECTOR_SIZE)
-		{
-			if (singleSector || !PrepareNextSector())
-			{
-				return bytesRead;
-			}
-		}
-    }
-
-	return bytesRead;
-
+	return ReadBytesImpl(ptr, bytes, singleSector, 0, CD_SECTOR_SIZE);
 }
 
-size_t cd::IsoReader::SkipBytes(size_t bytes, bool singleSector) {
-
-	if (currentSector >= totalSectors) {
-		return 0;
-	}
-
-	size_t bytesRead = 0;
-    while(bytes > 0) {
-
-        const size_t toRead = std::min(F1_DATA_SIZE - currentByte, bytes);
-
-		currentByte += toRead;
-		bytesRead += toRead;
-		bytes -= toRead;
-
-		if (currentByte >= F1_DATA_SIZE) {
-
-            if (singleSector || !PrepareNextSector())
-			{
-				return bytesRead;
-			}
-		}
-    }
-
-	return bytesRead;
+size_t cd::IsoReader::SkipBytes(size_t bytes, bool singleSector)
+{
+	constexpr size_t DATA_BEG = offsetof(cd::SECTOR_M2F1, data);
+	return ReadBytesImpl(nullptr, bytes, singleSector, DATA_BEG, DATA_BEG + F1_DATA_SIZE);
 }
 
 bool cd::IsoReader::SeekToSector(int sector) {
@@ -266,7 +213,7 @@ size_t cd::IsoPathTable::ReadPathTable(cd::IsoReader* reader, int lba, unsigned 
 			// ECMA-119 9.4.6 - 00 field present only if entry length is an odd number
 			if ((length % 2) != 0)
 			{
-				bytesRead += reader->SkipBytes(1);
+				bytesRead += reader->SkipBytes(1, true);
 			}
 
 			// Strip trailing zeroes, if any
@@ -413,7 +360,7 @@ std::optional<cd::IsoDirEntries::Entry> cd::IsoDirEntries::ReadEntry(cd::IsoRead
 	// ECMA-119 9.1.12 - 00 field present only if file identifier length is an even number
 	if ((entry.entry.identifierLen % 2) == 0)
     {
-		bytesRead += reader->SkipBytes(1);
+		bytesRead += reader->SkipBytes(1, true);
     }
 
 	// Read XA attribute data

--- a/src/dumpsxiso/cdreader.h
+++ b/src/dumpsxiso/cdreader.h
@@ -48,10 +48,10 @@ namespace cd {
         size_t SkipBytes(size_t bytes, bool singleSector = false);
 
         // Seek to a sector in the ISO image in sector units (returns true if success)
-        bool SeekToSector(int sector);
+        bool SeekToSector(const uint32_t sector);
 
-        // Seek to a data offset in the ISO image in byte units
-        size_t SeekToByte(size_t offs);
+        // Seek to a data offset in the ISO image in byte units (returns true if success)
+        bool SeekToByte(const size_t offs);
 
         // Get current offset in byte units
         size_t GetPos() const;
@@ -60,6 +60,7 @@ namespace cd {
         void Close();
 
     private:
+        bool ReadSector();
         bool PrepareNextSector();
         size_t ReadBytesImpl(void* ptr, size_t bytes, const bool singleSector, const size_t dataBeg, const size_t dataEnd);
 

--- a/src/dumpsxiso/cdreader.h
+++ b/src/dumpsxiso/cdreader.h
@@ -64,6 +64,7 @@ namespace cd {
         size_t ReadBytesImpl(void* ptr, size_t bytes, const bool singleSector, const size_t dataBeg, const size_t dataEnd);
 
     };
+    inline std::unique_ptr<IsoReader> reader;
 
     class IsoPathTable
     {

--- a/src/dumpsxiso/cdreader.h
+++ b/src/dumpsxiso/cdreader.h
@@ -35,16 +35,16 @@ namespace cd {
         // Open ISO image
         bool Open(const fs::path& fileName);
 
-        // Read form1 data(2048) sector in bytes (supports sequential reading)
+        // Read bytes from M2F1 sector payload (2048: Data) (supports sequential reading)
         size_t ReadBytes(void* ptr, size_t bytes, bool singleSector = false);
 
-        // Read form2 subheader+data+edc(2336) sector in bytes (supports sequential reading)
+        // Read bytes from M2F2 sector payload (2336: Sub+Data+EDC) (supports sequential reading)
         size_t ReadBytesXA(void* ptr, size_t bytes, bool singleSector = false);
 
-        // Read whole(2352) sector in bytes (supports sequential reading)
+        // Read bytes from RAW sector payload (2352: Whole) (supports sequential reading)
         size_t ReadBytesDA(void* ptr, size_t bytes, bool singleSector = false);
 
-        // Skip bytes in data sectors (supports sequential skipping)
+        // Skip bytes from M2F1 sector payload (2048: Data) (supports sequential skipping)
         size_t SkipBytes(size_t bytes, bool singleSector = false);
 
         // Seek to a sector in the ISO image in sector units (returns true if success)
@@ -61,6 +61,7 @@ namespace cd {
 
     private:
         bool PrepareNextSector();
+        size_t ReadBytesImpl(void* ptr, size_t bytes, const bool singleSector, const size_t dataBeg, const size_t dataEnd);
 
     };
 

--- a/src/dumpsxiso/cdreader.h
+++ b/src/dumpsxiso/cdreader.h
@@ -102,12 +102,12 @@ namespace cd {
         };
         ListView<Entry> dirEntryList;
 
-        IsoDirEntries(ListView<Entry> view);
+        explicit IsoDirEntries(ListView<Entry> view);
         void ReadDirEntries(cd::IsoReader* reader, int lba, int sectors);
         void ReadRootDir(cd::IsoReader* reader, int lba);
 
     private:
-        std::optional<Entry> ReadEntry(cd::IsoReader* reader) const;
+        static std::optional<Entry> ReadEntry(cd::IsoReader* reader);
     };
 
 }

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -57,6 +57,8 @@ namespace param {
 namespace global
 {
 	CueFile cueFile;
+	bool ps2 = false;
+	bool xa_edc = true;
 	std::optional<bool> new_type;
 }
 
@@ -142,12 +144,14 @@ void prepareRIFFHeader(cd::RIFF_HEADER* header, int dataSize) {
 
 // This will ensure that the EDC remains the same as in the original file. Games built with an old, buggy Sony's mastering tool version
 // don't have EDC Form2 data (this can be checked at redump.org) and some games rely on this to do anti-piracy checks like DDR.
-const bool CheckEDCXA(cd::IsoReader &reader) {
+const bool CheckEDCXA()
+{
 	cd::SECTOR_M2F2 sector;
-	while (reader.ReadBytesXA(sector.subHead, XA_DATA_SIZE))
+	while (cd::reader->ReadBytesXA(sector.subHead, XA_DATA_SIZE))
 	{
-		if (sector.subHead[2] & 0x20) {
-			if (!memcmp(sector.edc, "\0\0\0\0", sizeof(sector.edc)))
+		if (sector.subHead[2] & 0x20)
+		{
+			if (memcmp(sector.edc, "\0\0\0\0", sizeof(sector.edc)) == 0)
 			{
 				return false;
 			}
@@ -159,16 +163,16 @@ const bool CheckEDCXA(cd::IsoReader &reader) {
 
 // Games from 2003 and onwards apparenly has built with a newer Sony's mastering tool.
 // These has different submode in the descriptor sectors, a correct root year value and files are sorted by LBA instead by name.
-const bool CheckISOver(cd::IsoReader &reader, bool& ps2)
+const bool CheckISOver()
 {
 	cd::SECTOR_M2F2 sector;
-	reader.SeekToSector(15);
-	reader.ReadBytesXA(sector.subHead, XA_DATA_SIZE);
+	cd::reader->SeekToSector(15);
+	cd::reader->ReadBytesXA(sector.subHead, XA_DATA_SIZE);
 	if (sector.subHead[2] & 0x08)
 	{
-		ps2 = true;
+		global::ps2 = true;
 	}
-	reader.ReadBytesXA(sector.subHead, XA_DATA_SIZE, true);
+	cd::reader->ReadBytesXA(sector.subHead, XA_DATA_SIZE, true);
 	if (sector.subHead[2] & 0x01)
 	{
 		return false;
@@ -1068,10 +1072,9 @@ void WriteXMLByDirectories(const cd::IsoDirEntries* directory, tinyxml2::XMLElem
 void ParseISO(cd::IsoReader& reader) {
 
     cd::ISO_DESCRIPTOR descriptor;
-	bool ps2 = false;
 	auto license = ReadLicense(reader);
-	const bool xa_edc = CheckEDCXA(reader);
-	global::new_type = CheckISOver(reader, ps2);
+	global::xa_edc = CheckEDCXA();
+	global::new_type = CheckISOver();
 
     reader.SeekToSector(16);
     reader.ReadBytes(&descriptor, F1_DATA_SIZE);
@@ -1219,11 +1222,11 @@ void ParseISO(cd::IsoReader& reader) {
 
 			tinyxml2::XMLElement *trackElement = baseElement->InsertNewChildElement(xml::elem::TRACK);
 			trackElement->SetAttribute(xml::attrib::TRACK_TYPE, "data");
-			trackElement->SetAttribute(xml::attrib::XA_EDC, xa_edc);
+			trackElement->SetAttribute(xml::attrib::XA_EDC, global::xa_edc);
 			trackElement->SetAttribute(xml::attrib::NEW_TYPE, *global::new_type);
-			if (ps2)
+			if (global::ps2)
 			{
-				trackElement->SetAttribute(xml::attrib::PS2, ps2);
+				trackElement->SetAttribute(xml::attrib::PS2, global::ps2);
 			}
 
 			{
@@ -1505,7 +1508,7 @@ int Main(int argc, char *argv[])
 		global::cueFile = parseCueFile(param::isoFile);
 	}
 
-	cd::IsoReader reader;
+	cd::IsoReader& reader = *(cd::reader = std::make_unique<cd::IsoReader>());
 
 	if (!reader.Open(param::isoFile)) {
 

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -2,7 +2,6 @@
 #include "xml.h"
 #include "cue.h"
 #include <map>
-#include <format>
 
 #ifndef MKPSXISO_NO_LIBFLAC
 #include "FLAC/stream_encoder.h"
@@ -545,7 +544,7 @@ std::list<cd::IsoDirEntries::Entry*> ParseDAfiles(cd::IsoReader& reader, std::li
 	{
 		if(entry.type == EntryType::EntryDA)
 		{
-			entry.trackid = std::format("{:02}", tracknum);
+			entry.trackid = std::to_string(100 + tracknum).substr(1);
 			tracknum++;
 			DAfiles.push_back(&entry);
 		}
@@ -613,7 +612,7 @@ std::list<cd::IsoDirEntries::Entry*> ParseDAfiles(cd::IsoReader& reader, std::li
 			{
 				if(!entry->trackid.empty())
 				{
-					entry->trackid = std::format("{:02}", tracknum);
+					entry->trackid = std::to_string(100 + tracknum).substr(1);
 				}
 				tracknum++;
 			}
@@ -658,12 +657,12 @@ void BruteForce(cd::IsoReader& reader, std::list<cd::IsoDirEntries::Entry>& entr
 				gapEntry->extData.attributes 	  = rootPrm;
 				if ((sector.subHead[2] & 0x7E) == 0x08)
 				{
-					gapEntry->identifier = std::format("UNKN{:04}.{};1", fileCount++, "DAT");
+					gapEntry->identifier = "UNKN" + std::to_string(10000 + fileCount++).substr(1) + ".DAT";
 					gapEntry->type = EntryType::EntryFile;
 				}
 				else
 				{
-					gapEntry->identifier = std::format("UNKN{:04}.{};1", fileCount++, "STR");
+					gapEntry->identifier = "UNKN" + std::to_string(10000 + fileCount++).substr(1) + ".STR";
 					gapEntry->type = EntryType::EntryXA;
 				}
 			}

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -108,7 +108,7 @@ void PrintDate(const char* label, const cd::ISO_LONG_DATESTAMP& date)
 }
 
 template<size_t N>
-static std::string_view CleanDescElement(char (&id)[N])
+static std::string_view CleanDescElement(const char (&id)[N])
 {
 	std::string_view result;
 
@@ -575,21 +575,14 @@ std::list<cd::IsoDirEntries::Entry*> ParseDAfiles(cd::IsoReader& reader, std::li
 			// For ex, Mega Man X3 track 30 had 149 sectors pause, but at redump.org says it was a 150 standard one
 			unsigned char sectorBuff[CD_SECTOR_SIZE];
 			unsigned char emptyBuff[CD_SECTOR_SIZE] {};
-			while (true)
+			while (reader.SeekToSector(entry.entry.entryOffs.lsb - 1) || multiBinSeeker(entry.entry.entryOffs.lsb - 1, entry, reader, global::cueFile))
 			{
-				if (!reader.SeekToSector(entry.entry.entryOffs.lsb - 1) && !multiBinSeeker(entry.entry.entryOffs.lsb - 1, entry, reader, global::cueFile))
+				reader.ReadBytesDA(sectorBuff, CD_SECTOR_SIZE, true);
+				if (memcmp(sectorBuff, emptyBuff, CD_SECTOR_SIZE) == 0)
 					break;
 
-				reader.ReadBytesDA(sectorBuff, CD_SECTOR_SIZE, true);
-				if (memcmp(sectorBuff, emptyBuff, CD_SECTOR_SIZE))
-				{
-					entry.entry.entryOffs.lsb--;
-					entry.entry.entrySize.lsb += F1_DATA_SIZE;
-				}
-				else
-				{
-					break;
-				}
+				entry.entry.entryOffs.lsb--;
+				entry.entry.entrySize.lsb += F1_DATA_SIZE;
 			}
 		}
 
@@ -628,12 +621,12 @@ std::list<cd::IsoDirEntries::Entry*> ParseDAfiles(cd::IsoReader& reader, std::li
 	return DAfiles;
 }
 
-void BruteForce(cd::IsoReader& reader, std::list<cd::IsoDirEntries::Entry>& entries, unsigned int currentLBA, unsigned int totalLenLBA)
+void BruteForce(cd::IsoReader& reader, std::list<cd::IsoDirEntries::Entry>& entries, unsigned int currentLBA, const unsigned int totalLenLBA)
 {
 	cd::SECTOR_M2F2 sector;
-	int filenum = 0;
+	int fileCount = 0;
 
-	auto processGaps = [&](unsigned int endLBA)
+	auto processGaps = [&](const unsigned int endLBA)
 	{
 		cd::IsoDirEntries::Entry* gapEntry = &entries.front(); // Get root stats
 		signed char rootGMTOff = gapEntry->entry.entryDate.GMToffs;
@@ -660,12 +653,12 @@ void BruteForce(cd::IsoReader& reader, std::list<cd::IsoDirEntries::Entry>& entr
 				gapEntry->extData.attributes 	  = rootPrm;
 				if ((sector.subHead[2] & 0x7E) == 0x08)
 				{
-					gapEntry->identifier = std::format("UNKN{:04}.{};1", filenum++, "DAT");
+					gapEntry->identifier = std::format("UNKN{:04}.{};1", fileCount++, "DAT");
 					gapEntry->type = EntryType::EntryFile;
 				}
 				else
 				{
-					gapEntry->identifier = std::format("UNKN{:04}.{};1", filenum++, "STR");
+					gapEntry->identifier = std::format("UNKN{:04}.{};1", fileCount++, "STR");
 					gapEntry->type = EntryType::EntryXA;
 				}
 			}
@@ -1153,7 +1146,7 @@ void ParseISO(cd::IsoReader& reader) {
 	// Process DA tracks and add them to the entries list
 	auto DAfiles = ParseDAfiles(reader, entries);
 
-	unsigned totalLenLBA = descriptor.volumeSize.lsb;
+	const unsigned totalLenLBA = descriptor.volumeSize.lsb;
 	if (param::force)
 	{
 		BruteForce(reader, entries, descriptor.rootDirRecord.entryOffs.lsb, totalLenLBA);

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -144,7 +144,7 @@ void prepareRIFFHeader(cd::RIFF_HEADER* header, int dataSize) {
 // don't have EDC Form2 data (this can be checked at redump.org) and some games rely on this to do anti-piracy checks like DDR.
 const bool CheckEDCXA(cd::IsoReader &reader) {
 	cd::SECTOR_M2F2 sector;
-	while (reader.ReadBytesXA(sector.subHead, XA_DATA_SIZE, true))
+	while (reader.ReadBytesXA(sector.subHead, XA_DATA_SIZE))
 	{
 		if (sector.subHead[2] & 0x20) {
 			if (!memcmp(sector.edc, "\0\0\0\0", sizeof(sector.edc)))

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -59,7 +59,7 @@ namespace global
 	CueFile cueFile;
 	bool ps2 = false;
 	bool xa_edc = true;
-	std::optional<bool> new_type;
+	std::optional<bool> cdvd_style;
 }
 
 fs::path GetEncodedDAPath(const fs::path& inputPath)
@@ -161,8 +161,9 @@ const bool CheckEDCXA()
 	return true;
 }
 
-// Games from 2003 and onwards apparenly has built with a newer Sony's mastering tool.
-// These has different submode in the descriptor sectors, a correct root year value and files are sorted by LBA instead by name.
+// Some games from ~2003 apparently were built with a tool newer than Sony CD-ROM Generator 1.40.
+// Likely an internal transition tool that shares the Sony CD/DVD-ROM Generator engine layout logic.
+// These have different submodes in the descriptor sectors, a correct root year value and entries are not sorted by name.
 const bool CheckISOver()
 {
 	cd::SECTOR_M2F2 sector;
@@ -459,7 +460,7 @@ std::unique_ptr<cd::IsoDirEntries> ParsePathTable(cd::IsoReader& reader, ListVie
 
 	// Calculate Directory Record sector size
 	int dirRecordSectors = 0;
-	if (*global::new_type && pathTableList.size() != index + 1)
+	if (*global::cdvd_style && pathTableList.size() != index + 1)
 	{
 		dirRecordSectors = pathTableList[index + 1].entry.dirOffs - pathTableList[index].entry.dirOffs;
 	}
@@ -1074,7 +1075,7 @@ void ParseISO(cd::IsoReader& reader) {
     cd::ISO_DESCRIPTOR descriptor;
 	auto license = ReadLicense(reader);
 	global::xa_edc = CheckEDCXA();
-	global::new_type = CheckISOver();
+	global::cdvd_style = CheckISOver();
 
     reader.SeekToSector(16);
     reader.ReadBytes(&descriptor, F1_DATA_SIZE);
@@ -1223,7 +1224,7 @@ void ParseISO(cd::IsoReader& reader) {
 			tinyxml2::XMLElement *trackElement = baseElement->InsertNewChildElement(xml::elem::TRACK);
 			trackElement->SetAttribute(xml::attrib::TRACK_TYPE, "data");
 			trackElement->SetAttribute(xml::attrib::XA_EDC, global::xa_edc);
-			trackElement->SetAttribute(xml::attrib::NEW_TYPE, *global::new_type);
+			trackElement->SetAttribute(xml::attrib::CDVD_STYLE, *global::cdvd_style);
 			if (global::ps2)
 			{
 				trackElement->SetAttribute(xml::attrib::PS2, global::ps2);

--- a/src/mkpsxiso/cdwriter.cpp
+++ b/src/mkpsxiso/cdwriter.cpp
@@ -11,14 +11,6 @@ namespace global
 	extern bool xa_edc;
 }
 
-ISO_USHORT_PAIR cd::SetPair16(unsigned short val) {
-    return { val, SwapBytes16(val) };
-}
-
-ISO_UINT_PAIR cd::SetPair32(unsigned int val) {
-	return { val, SwapBytes32(val) };
-}
-
 bool IsoWriter::Create(const fs::path& fileName, unsigned int sizeLBA)
 {
 	const uint64_t sizeBytes = static_cast<uint64_t>(sizeLBA) * CD_SECTOR_SIZE;

--- a/src/mkpsxiso/cdwriter.cpp
+++ b/src/mkpsxiso/cdwriter.cpp
@@ -29,11 +29,11 @@ void IsoWriter::Close()
 // ======================================================
 
 IsoWriter::SectorView::SectorView(ThreadPool* threadPool, MMappedFile* mappedFile, unsigned int offsetLBA, unsigned int sizeLBA, EdcEccForm edcEccForm)
-	: m_threadPool(threadPool) 
-	, m_view(mappedFile->GetView(static_cast<uint64_t>(offsetLBA) * CD_SECTOR_SIZE, static_cast<size_t>(sizeLBA) * CD_SECTOR_SIZE))
-	, m_currentLBA(offsetLBA)
+	: m_currentLBA(offsetLBA)
 	, m_endLBA(offsetLBA + sizeLBA)
 	, m_edcEccForm(edcEccForm)
+	, m_threadPool(threadPool)
+	, m_view(mappedFile->GetView(static_cast<uint64_t>(offsetLBA) * CD_SECTOR_SIZE, static_cast<size_t>(sizeLBA) * CD_SECTOR_SIZE))
 {
 	m_currentSector = m_view.GetBuffer();
 }

--- a/src/mkpsxiso/cdwriter.cpp
+++ b/src/mkpsxiso/cdwriter.cpp
@@ -145,7 +145,7 @@ public:
 		while (m_currentLBA < m_endLBA)
 		{
 			PrepareSectorHeader();
-			SetSubHeader(sector->subHead, m_currentLBA != lastLBA ? m_subHeader : IsoWriter::SubEOF);
+			SetSubHeader(sector->subHead, m_currentLBA != lastLBA ? m_subHeader : IsoWriter::SubEOX);
 
 			const size_t bytesRead = fread(sector->data, 1, F1_DATA_SIZE, file);
 			// Fill the remainder of the sector with zeroes if applicable
@@ -165,7 +165,7 @@ public:
 		}
 	}
 
-	void WriteMemory(const void* memory, size_t size) override
+	void WriteMemory(const void* memory, size_t size, const bool setEOX) override
 	{
 		const char* buf = static_cast<const char*>(memory);
 		const unsigned int lastLBA = m_endLBA - 1;
@@ -177,7 +177,7 @@ public:
 			if (m_offsetInSector == 0)
 			{
 				PrepareSectorHeader();
-				SetSubHeader(sector->subHead, m_currentLBA != lastLBA ? m_subHeader : IsoWriter::SubEOF);
+				SetSubHeader(sector->subHead, m_currentLBA != lastLBA || !setEOX ? m_subHeader : IsoWriter::SubEOX);
 			}
 
 			const size_t memToCopy = std::min(GetSpaceInCurrentSector(), size);
@@ -324,7 +324,7 @@ public:
 		}
 	}
 
-	void WriteMemory(const void* memory, size_t size) override
+	void WriteMemory(const void* memory, size_t size, const bool /*setEOX*/) override
 	{
 		const char* buf = static_cast<const char*>(memory);
 

--- a/src/mkpsxiso/cdwriter.h
+++ b/src/mkpsxiso/cdwriter.h
@@ -48,7 +48,6 @@ public:
 		void CalculateForm1(const bool eccAddr = false);
 		void CalculateForm2();
 
-	protected:
 		void* m_currentSector = nullptr;
 		size_t m_offsetInSector = 0;
 		unsigned int m_currentLBA = 0;

--- a/src/mkpsxiso/cdwriter.h
+++ b/src/mkpsxiso/cdwriter.h
@@ -21,10 +21,10 @@ public:
 	};
 		
 	enum {
-		SubData	= 0x00080000,
-		SubSTR	= 0x00480100,
-		SubEOL	= 0x00090000,
-		SubEOF	= 0x00890000,
+		SubData	= 0x00080000, // Data
+		SubSTR	= 0x00480100, // Stream (0x01: CN, 0x48: RT | Data)
+		SubEOR	= 0x00090000, // End of Record
+		SubEOX	= 0x00890000, // End of Extent (0x89: EOF | Data | EOR)
 	};
 
 	class SectorView
@@ -34,7 +34,7 @@ public:
 		virtual ~SectorView();
 
 		virtual void WriteFile(FILE* file) = 0;
-		virtual void WriteMemory(const void* memory, size_t size) = 0;
+		virtual void WriteMemory(const void* memory, size_t size, const bool setEOX = true) = 0;
 		virtual void WriteBlankSectors(unsigned int count, const unsigned char submode = 0x20, const bool eccAddr = false) = 0;
 		virtual size_t GetSpaceInCurrentSector() const = 0;
 		virtual void NextSector() = 0;

--- a/src/mkpsxiso/cdwriter.h
+++ b/src/mkpsxiso/cdwriter.h
@@ -89,9 +89,6 @@ private:
 	std::unique_ptr<ThreadPool> m_threadPool;
 };
 
-ISO_USHORT_PAIR SetPair16(unsigned short val);
-ISO_UINT_PAIR SetPair32(unsigned int val);
-
 };
 
 #endif // _CDWRITER_H

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -808,57 +808,6 @@ int iso::DirTreeClass::CalculatePathTableLen(const DIRENTRY& dirEntry) const
 	return len;
 }
 
-std::unique_ptr<iso::PathTableClass> iso::DirTreeClass::GenPathTableSub(unsigned short& index, const unsigned short parentIndex) const
-{
-	auto table = std::make_unique<PathTableClass>();
-	std::queue<std::tuple<const DirTreeClass*, unsigned short>> dirsToProcess;
-	dirsToProcess.emplace(this, parentIndex);
-
-	while (!dirsToProcess.empty())
-	{
-		const auto [currentDir, currentParentIndex] = dirsToProcess.front();
-		dirsToProcess.pop();
-
-		for (const auto& e : currentDir->entriesInDir)
-		{
-			const DIRENTRY& entry = e.get();
-			if (entry.type == EntryType::EntryDir)
-			{
-				table->entries.emplace_back(PathEntryClass{
-					entry.id,
-					index++,
-					currentParentIndex,
-					entry.lba
-				});
-
-				dirsToProcess.emplace(entry.subdir.get(), index - 1);
-			}
-		}
-	}
-	return table;
-}
-
-int iso::DirTreeClass::GeneratePathTable(const DIRENTRY& root, unsigned char* buff, bool msb) const
-{
-	unsigned short index = 1;
-
-	// Write out root explicitly (since there is no DirTreeClass including it)
-	PathEntryClass rootEntry;
-	rootEntry.dir_id = root.id;
-	rootEntry.dir_parent_index = index;
-	rootEntry.dir_index = index++;
-	rootEntry.dir_lba = root.lba;
-	rootEntry.sub = GenPathTableSub(index, rootEntry.dir_parent_index);
-
-	PathTableClass pathTable;
-	pathTable.entries.emplace_back(std::move(rootEntry));
-
-	unsigned char* newbuff = pathTable.GenTableData( buff, msb );
-
-	return (int)(newbuff-buff);
-
-}
-
 int iso::DirTreeClass::GetFileCountTotal() const
 {
     int numfiles = 0;
@@ -1040,7 +989,7 @@ void iso::DirTreeClass::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTI
 	const size_t pathTableSize = static_cast<size_t>(F1_DATA_SIZE)*pathTableSectors;
 	auto sectorBuff = std::make_unique<unsigned char[]>(pathTableSize);
 
-	GeneratePathTable( *m_entry, sectorBuff.get(), false );
+	GeneratePathTable( sectorBuff.get(), false );
 	auto lpathTable1 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors, cd::IsoWriter::EdcEccForm::Form1);
 	lpathTable1->WriteMemory(sectorBuff.get(), pathTableSize, setEnd);
 	currentHeaderLBA += pathTableSectors;
@@ -1050,7 +999,7 @@ void iso::DirTreeClass::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTI
 	currentHeaderLBA += pathTableSectors;
 
 	// Generate and write M-path table
-	GeneratePathTable( *m_entry, sectorBuff.get(), true );
+	GeneratePathTable( sectorBuff.get(), true );
 	auto mpathTable1 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors, cd::IsoWriter::EdcEccForm::Form1);
 	mpathTable1->WriteMemory(sectorBuff.get(), pathTableSize, setEnd);
 	currentHeaderLBA += pathTableSectors;
@@ -1059,9 +1008,55 @@ void iso::DirTreeClass::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTI
 	mpathTable2->WriteMemory(sectorBuff.get(), pathTableSize, setEnd);
 }
 
+int iso::DirTreeClass::GeneratePathTable(unsigned char* buff, bool msb) const
+{
+	unsigned short index = 1;
+	PathTableClass pathTable;
+
+	// Write out root explicitly first
+	pathTable.entries.emplace_back(
+		m_entry->id,
+		index,
+		index, // Self for Root
+		m_entry->lba
+	);
+
+	// Initialize Breadth-First Search Queue
+	std::queue<std::tuple<const DirTreeClass*, unsigned short>> dirsToProcess;
+	dirsToProcess.emplace(this, index++);
+
+	// Process directories using BFS
+	while (!dirsToProcess.empty())
+	{
+		const auto [currentDir, parentIndex] = dirsToProcess.front();
+		dirsToProcess.pop();
+
+		for (const DIRENTRY& entry : currentDir->entriesInDir)
+		{
+			if (entry.type == EntryType::EntryDir)
+			{
+				pathTable.entries.emplace_back(
+					entry.id,
+					index,
+					parentIndex,
+					entry.lba
+				);
+
+				// Queue subdirectories
+				dirsToProcess.emplace(entry.subdir.get(), index++);
+			}
+		}
+	}
+
+	// Generate data buffer
+	const unsigned char* endPtr = pathTable.GenTableData(buff, msb);
+
+	return static_cast<int>(endPtr - buff);
+}
+
 unsigned char* iso::PathTableClass::GenTableData(unsigned char* buff, bool msb)
 {
-	for ( const PathEntryClass& entry : entries )
+	for ( const PathEntry& entry : entries )
 	{
 		const int idLength = MinimumOne(entry.dir_id.length());
 		*buff++ = idLength;	// Directory identifier length
@@ -1088,15 +1083,5 @@ unsigned char* iso::PathTableClass::GenTableData(unsigned char* buff, bool msb)
 		buff += RoundToEven(idLength);
 	}
 
-	for ( const PathEntryClass& entry : entries )
-	{
-		if ( entry.sub != nullptr )
-		{
-			buff = entry.sub->GenTableData( buff, msb );
-		}
-
-	}
-
 	return buff;
-
 }

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -388,16 +388,17 @@ int iso::DirTreeClass::CalculateDirEntryLen() const
 			dataLen += sizeof( cdxa::ISO_XA_ATTRIB );
 		}
 
-		if ( ((dirEntryLen % F1_DATA_SIZE) + dataLen) > F1_DATA_SIZE )
+		constexpr int SECTOR_MASK = F1_DATA_SIZE - 1;
+		if ( ((dirEntryLen & SECTOR_MASK) + dataLen) > F1_DATA_SIZE )
 		{
 			// Round dirEntryLen to the nearest multiple of 2048 as the rest of that sector is "unusable"
-			dirEntryLen = ((dirEntryLen + 2047) / F1_DATA_SIZE) * F1_DATA_SIZE;
+			dirEntryLen = (dirEntryLen + SECTOR_MASK) & ~SECTOR_MASK;
 		}
 
 		dirEntryLen += dataLen;
 	}
 
-	return F1_DATA_SIZE * GetSizeInSectors(dirEntryLen);
+	return dirEntryLen;
 }
 
 void iso::DirTreeClass::SortDirectoryEntries(const bool byOrder, const bool byLBA)
@@ -483,7 +484,7 @@ void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& d
 		}
 		else if (entry.type == EntryType::EntryDir)
 		{
-			length = entry.subdir->CalculateDirEntryLen();
+			length = F1_DATA_SIZE * GetSizeInSectors(entry.subdir->CalculateDirEntryLen());
 		}
 		else
 		{
@@ -1017,7 +1018,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 	isoDescriptor.rootDirRecord.entryLength = 34;
 	isoDescriptor.rootDirRecord.extLength	= 0;
 	isoDescriptor.rootDirRecord.entryOffs = SetPair32( 18+(pathTableSectors*4) );
-	isoDescriptor.rootDirRecord.entrySize = SetPair32( dirTree->CalculateDirEntryLen() );
+	isoDescriptor.rootDirRecord.entrySize = SetPair32( GetSizeInSectors(dirTree->CalculateDirEntryLen())*F1_DATA_SIZE );
 	isoDescriptor.rootDirRecord.flags = 0x02 | root.HF;
 	isoDescriptor.rootDirRecord.volSeqNum = SetPair16( 1 );
 	isoDescriptor.rootDirRecord.identifierLen = 1;

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -445,7 +445,7 @@ void iso::DirTreeClass::SortDirectoryEntries(const bool byOrder, const bool byLB
 	}
 }
 
-bool iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& dir, const DIRENTRY& parentDir, const int totalDirs) const
+void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& dir, const DIRENTRY& parentDir, const int totalDirs) const
 {
 	//char	dataBuff[2048] {};
 	//char*	dataBuffPtr=dataBuff;
@@ -570,63 +570,45 @@ bool iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& d
 			writeOneEntry(entry);
 		}
 	}
-
-	return true;
 }
 
-bool iso::DirTreeClass::WriteDirectoryRecords(cd::IsoWriter* writer, const DIRENTRY& root, int totalDirs)
+void iso::DirTreeClass::WriteDirectoryRecords(cd::IsoWriter* writer, const DIRENTRY& root, int totalDirs) const
 {
-	if(!WriteDirEntries( writer, root, root, totalDirs ))
-	{
-		return false;
-	}
+	WriteDirEntries( writer, root, root, totalDirs );
 
 	for ( const auto& entry : entries )
 	{
 		if ( !entry.id.empty() && entry.type == EntryType::EntryDir )
 		{
-			if (totalDirs > 0) {
+			if (totalDirs > 0)
+			{
 				totalDirs--;
 			}
-			if ( !entry.subdir->WriteDirEntries(writer, entry, *entry.subdir->parent->entry, totalDirs) )
-			{
-				return false;
-			}
+			entry.subdir->WriteDirEntries(writer, entry, *entry.subdir->parent->entry, totalDirs);
 		}
 	}
-
-	return true;
 }
 
-bool iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer) const
+void iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer) const
 {
 	for ( const DIRENTRY& entry : entries )
 	{
 		// Write files as regular data sectors
 		if ( entry.type == EntryType::EntryFile )
 		{
-			if ( !entry.srcfile.empty() )
+			if ( !global::QuietMode )
 			{
-				if ( !global::QuietMode )
-				{
-					printf( "    Packing \"%s\"... ", entry.srcfile.string().c_str() );
-					fflush(stdout);
-				}
+				printf( "    Packing \"%s\"... ", entry.srcfile.string().c_str() );
+				fflush(stdout);
+			}
 
-				FILE *fp = OpenFile( entry.srcfile, "rb" );
-				if (fp != nullptr)
-				{
-					auto sectorView = writer->GetSectorViewM2F1(entry.lba, GetSizeInSectors(entry.length), cd::IsoWriter::EdcEccForm::Form1);
-					sectorView->WriteFile(fp);
+			auto fp = OpenScopedFile( entry.srcfile, "rb" );
+			auto sectorView = writer->GetSectorViewM2F1(entry.lba, GetSizeInSectors(entry.length), cd::IsoWriter::EdcEccForm::Form1);
+			sectorView->WriteFile(fp.get());
 
-					fclose(fp);
-				}
-
-				if ( !global::QuietMode )
-				{
-					printf("Done.\n");
-				}
-
+			if ( !global::QuietMode )
+			{
+				printf("Done.\n");
 			}
 
 		// Write XA/STR video streams as Mode 2 Form 1 (video sectors) and Mode 2 Form 2 (XA audio sectors)
@@ -640,14 +622,9 @@ bool iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer) const
 				fflush(stdout);
 			}
 
-			FILE *fp = OpenFile( entry.srcfile, "rb" );
-			if (fp != nullptr)
-			{
-				auto sectorView = writer->GetSectorViewM2F2(entry.lba, GetSizeInSectors(entry.length, XA_DATA_SIZE), cd::IsoWriter::EdcEccForm::Autodetect);
-				sectorView->WriteFile(fp);
-
-				fclose( fp );
-			}			
+			auto fp = OpenScopedFile( entry.srcfile, "rb" );
+			auto sectorView = writer->GetSectorViewM2F2(entry.lba, GetSizeInSectors(entry.length, XA_DATA_SIZE), cd::IsoWriter::EdcEccForm::Autodetect);
+			sectorView->WriteFile(fp.get());
 
 			if (!global::QuietMode)
 			{
@@ -658,29 +635,20 @@ bool iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer) const
 		}
 		else if ( entry.type == EntryType::EntryXA_DO )
 		{
-			if ( !entry.srcfile.empty() )
+			if ( !global::QuietMode )
 			{
-				if ( !global::QuietMode )
-				{
-					printf( "    Packing XA-DO \"%s\"... ", entry.srcfile.string().c_str() );
-					fflush(stdout);
-				}
+				printf( "    Packing XA-DO \"%s\"... ", entry.srcfile.string().c_str() );
+				fflush(stdout);
+			}
 
-				FILE *fp = OpenFile( entry.srcfile, "rb" );
-				if (fp != nullptr)
-				{
-					auto sectorView = writer->GetSectorViewM2F1(entry.lba, GetSizeInSectors(entry.length), cd::IsoWriter::EdcEccForm::Form1);
-					sectorView->SetSubheader(cd::IsoWriter::SubSTR);
-					sectorView->WriteFile(fp);
+			auto fp = OpenScopedFile( entry.srcfile, "rb" );
+			auto sectorView = writer->GetSectorViewM2F1(entry.lba, GetSizeInSectors(entry.length), cd::IsoWriter::EdcEccForm::Form1);
+			sectorView->SetSubheader(cd::IsoWriter::SubSTR);
+			sectorView->WriteFile(fp.get());
 
-					fclose(fp);
-				}
-
-				if ( !global::QuietMode )
-				{
-					printf("Done.\n");
-				}
-
+			if ( !global::QuietMode )
+			{
+				printf("Done.\n");
 			}
 		}
 		// Write dummies as gaps without data
@@ -700,8 +668,6 @@ bool iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer) const
 			continue;
 		}
 	}
-
-	return true;
 }
 
 void iso::DirTreeClass::OutputHeaderListing(FILE* fp, int level) const

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -270,16 +270,6 @@ iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(std::string id, const fs::p
 	if (!fileAttrib.has_value())
 	{
 		fileAttrib.emplace().st_mtime = global::BuildTime;
-	
-		if ( !global::noWarns )
-		{
-			if ( !global::QuietMode )
-			{
-				printf( "\n    " );
-			}
-
-			printf( "WARNING: 'source' attribute for subdirectory '%s' is invalid or empty.\n", id.c_str() );
-		}
 	}
 
 	DIRENTRY& entry = entries.emplace_back();

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -65,7 +65,7 @@ static cd::ISO_DATESTAMP GetISODateStamp(time_t time, signed char GMToffs, const
 int iso::DirTreeClass::GetAudioSize(const fs::path& audioFile)
 {
 	ma_decoder decoder;
-	VirtualWavEx vw;
+	VirtualWav vw;
 	bool isLossy;
 	bool isPCM;
 	if(ma_redbook_decoder_init_path_by_ext(audioFile, &decoder, &vw, isLossy, isPCM) != MA_SUCCESS)

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -86,8 +86,8 @@ int iso::DirTreeClass::GetAudioSize(const fs::path& audioFile)
 	return GetSizeInSectors(expectedPCMFrames * 2 * (sizeof(int16_t)), CD_SECTOR_SIZE)*CD_SECTOR_SIZE;
 }
 
-iso::DirTreeClass::DirTreeClass(EntryList& entries, DirTreeClass* parent, std::string name)
-	: name(name), entries(entries), parent(parent)
+iso::DirTreeClass::DirTreeClass(EntryList& entries, DIRENTRY* entry, DirTreeClass* parent)
+	: m_entry(entry), m_parent(parent), entries(entries)
 {
 }
 
@@ -97,10 +97,10 @@ iso::DirTreeClass::~DirTreeClass()
 
 iso::DIRENTRY& iso::DirTreeClass::CreateRootDirectory(EntryList& entries, const cd::ISO_DATESTAMP& volumeDate, const EntryAttributes& attributes)
 {
-	DIRENTRY entry {};
+	DIRENTRY& entry = entries.emplace_back();
 
 	entry.type		= EntryType::EntryDir;
-	entry.subdir	= std::make_unique<DirTreeClass>(entries);
+	entry.subdir	= std::make_unique<DirTreeClass>(entries, &entry);
 	entry.date		= volumeDate;
 	if (!global::cdvd_style.value_or(false))
 	{
@@ -114,10 +114,7 @@ iso::DIRENTRY& iso::DirTreeClass::CreateRootDirectory(EntryList& entries, const 
 	entry.UID		= attributes.UID;
 	entry.flba		= attributes.FLBA;
 
-	entries.emplace_back( std::move(entry) );
-	entries.back().subdir->entry = &entries.back();
-
-	return entries.back();
+	return entry;
 }
 
 bool iso::DirTreeClass::AddFileEntry(std::string id, EntryType type, fs::path srcfile, const EntryAttributes& attributes, const char *trackid, const char* date)
@@ -208,7 +205,7 @@ bool iso::DirTreeClass::AddFileEntry(std::string id, EntryType type, fs::path sr
 		}
     }
 
-	DIRENTRY entry {};
+	DIRENTRY& entry = entries.emplace_back();
 
 	entry.id		= std::move(id);
 	entry.type		= type;
@@ -233,8 +230,7 @@ bool iso::DirTreeClass::AddFileEntry(std::string id, EntryType type, fs::path sr
 		entry.length = fileAttrib->st_size;
 	}
 
-	entries.emplace_back(std::move(entry));
-	entriesInDir.emplace_back(entries.back());
+	entriesInDir.emplace_back(entry);
 
 	return true;
 
@@ -242,9 +238,8 @@ bool iso::DirTreeClass::AddFileEntry(std::string id, EntryType type, fs::path sr
 
 void iso::DirTreeClass::AddDummyEntry(const unsigned int sectors, const unsigned char submode, const unsigned int flba, const bool eccAddr)
 {
-	DIRENTRY entry {};
+	DIRENTRY& entry = entries.emplace_back();
 
-	// TODO: HUGE HACK, will be removed once EntryDummy is unified with EntryFile again
 	entry.attribs	= submode;
 	entry.type		= EntryType::EntryDummy;
 	entry.length	= F1_DATA_SIZE * sectors;
@@ -252,8 +247,7 @@ void iso::DirTreeClass::AddDummyEntry(const unsigned int sectors, const unsigned
 	entry.order		= -1;
 	entry.HF		= eccAddr;
 
-	entries.emplace_back(std::move(entry));
-	entriesInDir.emplace_back(entries.back());
+	entriesInDir.emplace_back(entry);
 }
 
 iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(std::string id, const fs::path& srcDir, const EntryAttributes& attributes, bool& alreadyExists, const char* date)
@@ -288,11 +282,11 @@ iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(std::string id, const fs::p
 		}
 	}
 
-	DIRENTRY entry {};
+	DIRENTRY& entry = entries.emplace_back();
 
 	entry.id		= std::move(id);
 	entry.type		= EntryType::EntryDir;
-	entry.subdir	= std::make_unique<DirTreeClass>(entries, this);
+	entry.subdir	= std::make_unique<DirTreeClass>(entries, &entry, this);
 	entry.HF		= attributes.HFLAG % 4;
 	entry.attribs	= attributes.XAAttrib;
 	entry.perms		= attributes.XAPerm;
@@ -303,22 +297,20 @@ iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(std::string id, const fs::p
 	entry.date		= GetISODateStamp( fileAttrib->st_mtime, attributes.GMTOffs, date );
 	entry.length	= 0; // Length is meaningless for directories
 
-	entries.emplace_back(std::move(entry));
-	entries.back().subdir->entry = &entries.back();
-	entriesInDir.emplace_back(entries.back());
+	entriesInDir.emplace_back(entry);
 
-	return entries.back().subdir.get();
+	return entry.subdir.get();
 }
 
-void iso::DirTreeClass::PrintRecordPath()
+void iso::DirTreeClass::PrintRecordPath() const
 {
-	if ( parent == nullptr )
+	if ( m_parent == nullptr )
 	{
 		return;
 	}
 
-	parent->PrintRecordPath();
-	printf( "/%s", name.c_str() );
+	m_parent->PrintRecordPath();
+	printf( "/%s", m_entry->id.c_str() );
 }
 
 int iso::DirTreeClass::CalculateTreeLBA(int lba)
@@ -335,11 +327,6 @@ int iso::DirTreeClass::CalculateTreeLBA(int lba)
 		// If it is a subdir
 		if (entry.subdir != nullptr)
 		{
-			if (!entry.id.empty())
-			{
-				entry.subdir->name = entry.id;
-			}
-
 			size = GetSizeInSectors(entry.subdir->CalculateDirEntryLen());
 		}
 		else if (entry.type != EntryType::EntryDA)
@@ -440,16 +427,9 @@ void iso::DirTreeClass::SortDirectoryEntries(const bool byOrder, const bool byLB
 	}
 }
 
-void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& dir, const DIRENTRY& parentDir, const int totalDirs) const
+void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY* parentDir, const int totalDirs) const
 {
-	//char	dataBuff[2048] {};
-	//char*	dataBuffPtr=dataBuff;
-	//char	entryBuff[128];
-	//int		dirlen;
-
-	auto sectorView = writer->GetSectorViewM2F1(dir.lba, GetSizeInSectors(CalculateDirEntryLen()), cd::IsoWriter::EdcEccForm::Form1);
-
-	//writer->SeekToSector( dir.lba );
+	auto sectorView = writer->GetSectorViewM2F1(m_entry->lba, GetSizeInSectors(CalculateDirEntryLen()), cd::IsoWriter::EdcEccForm::Form1);
 
 	auto writeOneEntry = [&sectorView, totalDirs](const DIRENTRY& entry, std::optional<bool> currentOrParent = std::nullopt) -> void
 	{
@@ -554,8 +534,8 @@ void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& d
 		sectorView->WriteMemory(buffer, entryLength, totalDirs == 0);
 	};
 
-	writeOneEntry(dir, false);
-	writeOneEntry(parentDir, true);
+	writeOneEntry(*m_entry, false);
+	writeOneEntry(*parentDir, true);
 
 	for ( const auto& e : entriesInDir )
 	{
@@ -567,19 +547,23 @@ void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& d
 	}
 }
 
-void iso::DirTreeClass::WriteDirectoryRecords(cd::IsoWriter* writer, const DIRENTRY& root, int totalDirs) const
+void iso::DirTreeClass::WriteDirectoryRecords(cd::IsoWriter* writer) const
 {
-	WriteDirEntries( writer, root, root, totalDirs );
+	int totalDirs = global::cdvd_style.value_or(false) ? GetDirCountTotal() : 0;
 
-	for ( const auto& entry : entries )
+	// Write Root
+	WriteDirEntries( writer, m_entry, totalDirs );
+
+	// Root is always the first entry, so skip it
+	for ( auto it = std::next(entries.begin()); it != entries.end(); ++it )
 	{
-		if ( !entry.id.empty() && entry.type == EntryType::EntryDir )
+		if ( it->type == EntryType::EntryDir )
 		{
 			if (totalDirs > 0)
 			{
 				totalDirs--;
 			}
-			entry.subdir->WriteDirEntries(writer, entry, *entry.subdir->parent->entry, totalDirs);
+			it->subdir->WriteDirEntries(writer, it->subdir->m_parent->m_entry, totalDirs);
 		}
 	}
 }
@@ -665,7 +649,7 @@ void iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer) const
 	}
 }
 
-void iso::DirTreeClass::OutputHeaderListing(FILE* fp, int level) const
+void iso::DirTreeClass::OutputHeaderListing(FILE* fp, const int level, const char* name) const
 {
 	if ( level == 0 )
 	{
@@ -673,7 +657,7 @@ void iso::DirTreeClass::OutputHeaderListing(FILE* fp, int level) const
 		fprintf( fp, "#define _ISO_FILES\n\n" );
 	}
 
-	fprintf( fp, "/* %s */\n", name.c_str() );
+	fprintf( fp, "/* %s */\n", name );
 
 	for ( const auto& e : entriesInDir )
 	{
@@ -706,7 +690,7 @@ void iso::DirTreeClass::OutputHeaderListing(FILE* fp, int level) const
 		if ( entry.type == EntryType::EntryDir )
 		{
 			fprintf( fp, "\n" );
-			entry.subdir->OutputHeaderListing( fp, level+1 );
+			entry.subdir->OutputHeaderListing( fp, level+1, entry.id.c_str() );
 		}
 	}
 }
@@ -802,7 +786,7 @@ void iso::DirTreeClass::OutputLBAlisting(FILE* fp, int level) const
 
 	if ( level > 0 )
 	{
-		fprintf(fp, "%*s End  |%-14s|%-8s|%-7s|%-10s|%-11s|\n", level + 3, "", name.c_str(), "", "", "", "");
+		fprintf(fp, "%*s End  |%-14s|%-8s|%-7s|%-10s|%-11s|\n", level + 3, "", m_entry->id.c_str(), "", "", "", "");
 	}
 }
 
@@ -918,11 +902,11 @@ int iso::DirTreeClass::GetDirCountTotal() const
 int iso::DirTreeClass::GetPathDepth(size_t* pathLength) const
 {
 	int depth = 0;
-	for (auto current = this; current->parent != nullptr; current = current->parent)
+	for (auto current = this; current->m_parent != nullptr; current = current->m_parent)
 	{
 		depth++;
 		if (pathLength != nullptr)
-			*pathLength += current->entry->id.length();
+			*pathLength += current->m_entry->id.length();
 	}
 	return depth;
 }
@@ -962,7 +946,7 @@ static void CopyStringPadWithSpaces(char (&dest)[N], const char* src)
 	std::fill( begin, end, ' ' );
 }
 
-void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, const DIRENTRY& root, int imageLen)
+void iso::DirTreeClass::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, const int imageLen) const
 {
 	cd::ISO_DESCRIPTOR isoDescriptor {};
 
@@ -1005,8 +989,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 		strncpy( (char*)&isoDescriptor.appData[141], "CD-XA001", 8 );
 	}
 
-	const DirTreeClass* dirTree = root.subdir.get();
-	unsigned int pathTableLen = dirTree->CalculatePathTableLen(root);
+	unsigned int pathTableLen = CalculatePathTableLen(*m_entry);
 	unsigned int pathTableSectors = GetSizeInSectors(pathTableLen);
 
 	isoDescriptor.volumeSetSize = SetPair16( 1 );
@@ -1018,13 +1001,13 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 	isoDescriptor.rootDirRecord.entryLength = 34;
 	isoDescriptor.rootDirRecord.extLength	= 0;
 	isoDescriptor.rootDirRecord.entryOffs = SetPair32( 18+(pathTableSectors*4) );
-	isoDescriptor.rootDirRecord.entrySize = SetPair32( GetSizeInSectors(dirTree->CalculateDirEntryLen())*F1_DATA_SIZE );
-	isoDescriptor.rootDirRecord.flags = 0x02 | root.HF;
+	isoDescriptor.rootDirRecord.entrySize = SetPair32( GetSizeInSectors(CalculateDirEntryLen())*F1_DATA_SIZE );
+	isoDescriptor.rootDirRecord.flags = 0x02 | m_entry->HF;
 	isoDescriptor.rootDirRecord.volSeqNum = SetPair16( 1 );
 	isoDescriptor.rootDirRecord.identifierLen = 1;
 	isoDescriptor.rootDirRecord.identifier = 0x0;
 
-	isoDescriptor.rootDirRecord.entryDate = root.date;
+	isoDescriptor.rootDirRecord.entryDate = m_entry->date;
 
 	isoDescriptor.pathTable1Offs = 18;
 	isoDescriptor.pathTable2Offs = isoDescriptor.pathTable1Offs + pathTableSectors;
@@ -1057,7 +1040,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 	const size_t pathTableSize = static_cast<size_t>(F1_DATA_SIZE)*pathTableSectors;
 	auto sectorBuff = std::make_unique<unsigned char[]>(pathTableSize);
 
-	dirTree->GeneratePathTable( root, sectorBuff.get(), false );
+	GeneratePathTable( *m_entry, sectorBuff.get(), false );
 	auto lpathTable1 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors, cd::IsoWriter::EdcEccForm::Form1);
 	lpathTable1->WriteMemory(sectorBuff.get(), pathTableSize, setEnd);
 	currentHeaderLBA += pathTableSectors;
@@ -1067,7 +1050,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 	currentHeaderLBA += pathTableSectors;
 
 	// Generate and write M-path table
-	dirTree->GeneratePathTable( root, sectorBuff.get(), true );
+	GeneratePathTable( *m_entry, sectorBuff.get(), true );
 	auto mpathTable1 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors, cd::IsoWriter::EdcEccForm::Form1);
 	mpathTable1->WriteMemory(sectorBuff.get(), pathTableSize, setEnd);
 	currentHeaderLBA += pathTableSectors;

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -106,7 +106,7 @@ iso::DIRENTRY& iso::DirTreeClass::CreateRootDirectory(EntryList& entries, const 
 	{
 		entry.date.year = volumeDate.year % 0x64; // Root overflows dates past 99 for games built with Sony CD-ROM Generator 1.40 and older
 	}
-	entry.length	= 0; // Length is meaningless for directories
+	entry.length	= 0; // We will calculate the length later when all entries have been processed
 	entry.HF		= attributes.HFLAG % 4;
 	entry.attribs	= attributes.XAAttrib;
 	entry.perms		= attributes.XAPerm;
@@ -295,7 +295,7 @@ iso::DirTreeClass* iso::DirTreeClass::AddSubDirEntry(std::string id, const fs::p
 	entry.order		= attributes.ORDER;
 	entry.flba		= attributes.FLBA;
 	entry.date		= GetISODateStamp( fileAttrib->st_mtime, attributes.GMTOffs, date );
-	entry.length	= 0; // Length is meaningless for directories
+	entry.length	= 0; // We will calculate the length later when all entries have been processed
 
 	entriesInDir.emplace_back(entry);
 
@@ -327,7 +327,8 @@ int iso::DirTreeClass::CalculateTreeLBA(int lba)
 		// If it is a subdir
 		if (entry.subdir != nullptr)
 		{
-			size = GetSizeInSectors(entry.subdir->CalculateDirEntryLen());
+			entry.length = entry.subdir->CalculateDirEntryLen();
+			size = GetSizeInSectors(entry.length);
 		}
 		else if (entry.type != EntryType::EntryDA)
 		{
@@ -429,14 +430,13 @@ void iso::DirTreeClass::SortDirectoryEntries(const bool byOrder, const bool byLB
 
 void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY* parentDir, const int totalDirs) const
 {
-	auto sectorView = writer->GetSectorViewM2F1(m_entry->lba, GetSizeInSectors(CalculateDirEntryLen()), cd::IsoWriter::EdcEccForm::Form1);
+	auto sectorView = writer->GetSectorViewM2F1(m_entry->lba, GetSizeInSectors(m_entry->length), cd::IsoWriter::EdcEccForm::Form1);
 
 	auto writeOneEntry = [&sectorView, totalDirs](const DIRENTRY& entry, std::optional<bool> currentOrParent = std::nullopt) -> void
 	{
 		std::byte buffer[128] {};
 
 		auto dirEntry = reinterpret_cast<cd::ISO_DIR_ENTRY*>(buffer);
-		int entryLength = sizeof(*dirEntry);
 
 		if ( entry.type == EntryType::EntryDir )
 		{
@@ -464,7 +464,7 @@ void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY* p
 		}
 		else if (entry.type == EntryType::EntryDir)
 		{
-			length = F1_DATA_SIZE * GetSizeInSectors(entry.subdir->CalculateDirEntryLen());
+			length = F1_DATA_SIZE * GetSizeInSectors(entry.length);
 		}
 		else
 		{
@@ -489,7 +489,7 @@ void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY* p
 			dirEntry->identifierLen = 1;
 			identifierBuffer[0] = currentOrParent.value() ? '\1' : '\0';
 		}
-		entryLength += dirEntry->identifierLen;
+		int entryLength = sizeof(*dirEntry) + dirEntry->identifierLen;
 		entryLength = RoundToEven(entryLength);
 
 		if ( !global::noXA )
@@ -950,7 +950,7 @@ void iso::DirTreeClass::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTI
 	isoDescriptor.rootDirRecord.entryLength = 34;
 	isoDescriptor.rootDirRecord.extLength	= 0;
 	isoDescriptor.rootDirRecord.entryOffs = SetPair32( 18+(pathTableSectors*4) );
-	isoDescriptor.rootDirRecord.entrySize = SetPair32( GetSizeInSectors(CalculateDirEntryLen())*F1_DATA_SIZE );
+	isoDescriptor.rootDirRecord.entrySize = SetPair32( GetSizeInSectors(m_entry->length)*F1_DATA_SIZE );
 	isoDescriptor.rootDirRecord.flags = 0x02 | m_entry->HF;
 	isoDescriptor.rootDirRecord.volSeqNum = SetPair16( 1 );
 	isoDescriptor.rootDirRecord.identifierLen = 1;

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -477,7 +477,7 @@ void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY* p
 		{
 			// Special cases - current/parent directory entry
 			dirEntry->identifierLen = 1;
-			identifierBuffer[0] = currentOrParent.value() ? '\1' : '\0';
+			identifierBuffer[0] = *currentOrParent ? '\1' : '\0';
 		}
 		int entryLength = sizeof(*dirEntry) + dirEntry->identifierLen;
 		entryLength = RoundToEven(entryLength);
@@ -703,7 +703,7 @@ void iso::DirTreeClass::OutputLBAlisting(FILE* fp, int level) const
 		// Write size in byte units
 		fprintf(fp, "%-11s|", entry.type != EntryType::EntryDir ? std::to_string(entry.length).c_str() : "");
 		// Write source file path
-		fprintf(fp, "%s\n", entry.srcfile.string().c_str());
+		fprintf(fp, "%s\n", entry.srcfile.generic_string().c_str());
 	};
 
 	int maxlba = 0;

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -29,7 +29,7 @@ static cd::ISO_DATESTAMP GetISODateStamp(time_t time, signed char GMToffs, const
 		return result;
 
 	tm* timestamp;
-	if (global::new_type.has_value()) {
+	if (global::cdvd_style.has_value()) {
 		timestamp = CustomLocalTime(&time);
 	}
 	else {
@@ -92,9 +92,9 @@ iso::DIRENTRY& iso::DirTreeClass::CreateRootDirectory(EntryList& entries, const 
 	entry.type		= EntryType::EntryDir;
 	entry.subdir	= std::make_unique<DirTreeClass>(entries);
 	entry.date		= volumeDate;
-	if (!global::new_type.value_or(false))
+	if (!global::cdvd_style.value_or(false))
 	{
-		entry.date.year = volumeDate.year % 0x64; // Root overflows dates past 1999 for games built with old(<2003) mastering tool
+		entry.date.year = volumeDate.year % 0x64; // Root overflows dates past 99 for games built with Sony CD-ROM Generator 1.40 and older
 	}
 	entry.length	= 0; // Length is meaningless for directories
 	entry.HF		= attributes.HFLAG % 4;
@@ -1042,10 +1042,10 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 
 	// Write the descriptor
 	unsigned int currentHeaderLBA = 16;
-	const int ISOver = global::new_type.value_or(false);
+	const int ISOver = global::cdvd_style.value_or(false);
 
 	auto isoDescriptorSectors = writer->GetSectorViewM2F1(currentHeaderLBA, 2 + ISOver, cd::IsoWriter::EdcEccForm::Form1);
-	isoDescriptorSectors->SetSubheader(global::new_type.value_or(false) ? cd::IsoWriter::SubData : cd::IsoWriter::SubEOL);
+	isoDescriptorSectors->SetSubheader(global::cdvd_style.value_or(false) ? cd::IsoWriter::SubData : cd::IsoWriter::SubEOL);
 
 	isoDescriptorSectors->WriteMemory(&isoDescriptor, sizeof(isoDescriptor));
 

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -313,8 +313,7 @@ void iso::DirTreeClass::PrintRecordPath()
 
 int iso::DirTreeClass::CalculateTreeLBA(int lba)
 {
-	int maxFlba = 0;
-	int sizeMax = 0;
+	int size;
 
 	for ( DIRENTRY& entry : entries )
 	{
@@ -331,38 +330,23 @@ int iso::DirTreeClass::CalculateTreeLBA(int lba)
 				entry.subdir->name = entry.id;
 			}
 
-			lba += GetSizeInSectors(entry.subdir->CalculateDirEntryLen());		
+			size = GetSizeInSectors(entry.subdir->CalculateDirEntryLen());
+		}
+		else if (entry.type != EntryType::EntryDA)
+		{
+			// Increment LBA by the size of file
+			size = GetSizeInSectors(entry.length, entry.type == EntryType::EntryXA ? XA_DATA_SIZE : F1_DATA_SIZE);
 		}
 		else
 		{
-			// Increment LBA by the size of file
-			if ( entry.type == EntryType::EntryXA )
-			{
-				if (entry.flba > maxFlba) {
-					maxFlba = entry.flba;
-					sizeMax = GetSizeInSectors(entry.length, XA_DATA_SIZE);
-				}
-
-				lba += GetSizeInSectors(entry.length, XA_DATA_SIZE);
-			}
-			else if ( entry.type == EntryType::EntryDA )
-			{
-				// DA files don't take up any space in the ISO filesystem, they are just links to CD tracks
-				entry.lba = iso::DA_FILE_PLACEHOLDER_LBA; // we will write the lba into the filesystem when writing the CDDA track
-			}
-			else
-			{	
-				if (entry.flba > maxFlba) {
-					maxFlba = entry.flba;
-					sizeMax = GetSizeInSectors(entry.length, F1_DATA_SIZE);
-				}
-
-				lba += GetSizeInSectors(entry.length, F1_DATA_SIZE);
-			}
+			// DA files don't take up any space in the ISO filesystem, they are just links to CD tracks
+			entry.lba = iso::DA_FILE_PLACEHOLDER_LBA; // we will write the lba into the filesystem when writing the CDDA track
+			continue;
 		}
+
+		// Prevent rewind on forced LBAs
+		lba = std::max(lba, entry.lba + size);
 	}
-	if (maxFlba)
-		return maxFlba + sizeMax;
 
 	return lba;
 }

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -22,6 +22,16 @@ static const int RoundToEven(const int val)
 	return (val + 1) & -2;
 }
 
+static cd::ISO_USHORT_PAIR SetPair16(unsigned short val)
+{
+    return { val, SwapBytes16(val) };
+}
+
+static cd::ISO_UINT_PAIR SetPair32(unsigned int val)
+{
+	return { val, SwapBytes32(val) };
+}
+
 static cd::ISO_DATESTAMP GetISODateStamp(time_t time, signed char GMToffs, const char* date)
 {
 	cd::ISO_DATESTAMP result;
@@ -480,9 +490,9 @@ void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& d
 			length = entry.length;
 		}
 
-		dirEntry->entryOffs = cd::SetPair32( entry.lba );
-		dirEntry->entrySize = cd::SetPair32( length );
-		dirEntry->volSeqNum = cd::SetPair16( 1 );
+		dirEntry->entryOffs = SetPair32( entry.lba );
+		dirEntry->entrySize = SetPair32( length );
+		dirEntry->volSeqNum = SetPair16( 1 );
 		dirEntry->entryDate = entry.date;
 
 		// Normal case - write out the identifier
@@ -998,18 +1008,18 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 	unsigned int pathTableLen = dirTree->CalculatePathTableLen(root);
 	unsigned int pathTableSectors = GetSizeInSectors(pathTableLen);
 
-	isoDescriptor.volumeSetSize = cd::SetPair16( 1 );
-	isoDescriptor.volumeSeqNumber = cd::SetPair16( 1 );
-	isoDescriptor.sectorSize = cd::SetPair16( F1_DATA_SIZE );
-	isoDescriptor.pathTableSize = cd::SetPair32( pathTableLen );
+	isoDescriptor.volumeSetSize = SetPair16( 1 );
+	isoDescriptor.volumeSeqNumber = SetPair16( 1 );
+	isoDescriptor.sectorSize = SetPair16( F1_DATA_SIZE );
+	isoDescriptor.pathTableSize = SetPair32( pathTableLen );
 
 	// Setup the root directory record
 	isoDescriptor.rootDirRecord.entryLength = 34;
 	isoDescriptor.rootDirRecord.extLength	= 0;
-	isoDescriptor.rootDirRecord.entryOffs = cd::SetPair32( 18+(pathTableSectors*4) );
-	isoDescriptor.rootDirRecord.entrySize = cd::SetPair32( dirTree->CalculateDirEntryLen() );
+	isoDescriptor.rootDirRecord.entryOffs = SetPair32( 18+(pathTableSectors*4) );
+	isoDescriptor.rootDirRecord.entrySize = SetPair32( dirTree->CalculateDirEntryLen() );
 	isoDescriptor.rootDirRecord.flags = 0x02 | root.HF;
-	isoDescriptor.rootDirRecord.volSeqNum = cd::SetPair16( 1 );
+	isoDescriptor.rootDirRecord.volSeqNum = SetPair16( 1 );
 	isoDescriptor.rootDirRecord.identifierLen = 1;
 	isoDescriptor.rootDirRecord.identifier = 0x0;
 
@@ -1022,7 +1032,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 	isoDescriptor.pathTable1MSBoffs = SwapBytes32( isoDescriptor.pathTable1MSBoffs );
 	isoDescriptor.pathTable2MSBoffs = SwapBytes32( isoDescriptor.pathTable2MSBoffs );
 
-	isoDescriptor.volumeSize = cd::SetPair32( imageLen );
+	isoDescriptor.volumeSize = SetPair32( imageLen );
 
 	// Write the descriptor
 	unsigned int currentHeaderLBA = 16;

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -1004,12 +1004,11 @@ int iso::DirTreeClass::GeneratePathTable(unsigned char* buff, bool msb) const
 	PathTableClass pathTable;
 
 	// Write out root explicitly first
-	pathTable.entries.emplace_back(
+	pathTable.entries.push_back({
 		m_entry->id,
-		index,
 		index, // Self for Root
 		m_entry->lba
-	);
+	});
 
 	// Initialize Breadth-First Search Queue
 	std::queue<std::tuple<const DirTreeClass*, unsigned short>> dirsToProcess;
@@ -1025,12 +1024,11 @@ int iso::DirTreeClass::GeneratePathTable(unsigned char* buff, bool msb) const
 		{
 			if (entry.type == EntryType::EntryDir)
 			{
-				pathTable.entries.emplace_back(
+				pathTable.entries.push_back({
 					entry.id,
-					index,
 					parentIndex,
 					entry.lba
-				);
+				});
 
 				// Queue subdirectories
 				dirsToProcess.emplace(entry.subdir.get(), index++);

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -447,11 +447,11 @@ void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& d
 	//char	entryBuff[128];
 	//int		dirlen;
 
-	auto sectorView = writer->GetSectorViewM2F1(dir.lba, GetSizeInSectors(CalculateDirEntryLen()) + totalDirs, cd::IsoWriter::EdcEccForm::Form1);
+	auto sectorView = writer->GetSectorViewM2F1(dir.lba, GetSizeInSectors(CalculateDirEntryLen()), cd::IsoWriter::EdcEccForm::Form1);
 
 	//writer->SeekToSector( dir.lba );
 
-	auto writeOneEntry = [&sectorView](const DIRENTRY& entry, std::optional<bool> currentOrParent = std::nullopt) -> void
+	auto writeOneEntry = [&sectorView, totalDirs](const DIRENTRY& entry, std::optional<bool> currentOrParent = std::nullopt) -> void
 	{
 		std::byte buffer[128] {};
 
@@ -551,7 +551,7 @@ void iso::DirTreeClass::WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& d
 		{
 			sectorView->NextSector();
 		}
-		sectorView->WriteMemory(buffer, entryLength);
+		sectorView->WriteMemory(buffer, entryLength, totalDirs == 0);
 	};
 
 	writeOneEntry(dir, false);
@@ -1037,10 +1037,10 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 
 	// Write the descriptor
 	unsigned int currentHeaderLBA = 16;
-	const int ISOver = global::cdvd_style.value_or(false);
+	const bool setEnd = !global::cdvd_style.value_or(false);
 
-	auto isoDescriptorSectors = writer->GetSectorViewM2F1(currentHeaderLBA, 2 + ISOver, cd::IsoWriter::EdcEccForm::Form1);
-	isoDescriptorSectors->SetSubheader(global::cdvd_style.value_or(false) ? cd::IsoWriter::SubData : cd::IsoWriter::SubEOL);
+	auto isoDescriptorSectors = writer->GetSectorViewM2F1(currentHeaderLBA, 2, cd::IsoWriter::EdcEccForm::Form1);
+	isoDescriptorSectors->SetSubheader(setEnd ? cd::IsoWriter::SubEOR : cd::IsoWriter::SubData);
 
 	isoDescriptorSectors->WriteMemory(&isoDescriptor, sizeof(isoDescriptor));
 
@@ -1050,7 +1050,7 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 	isoDescriptor.header.version = 1;
 	CopyStringPadWithSpaces( isoDescriptor.header.id, "CD001" );
 
-	isoDescriptorSectors->WriteMemory(&isoDescriptor, sizeof(isoDescriptor));
+	isoDescriptorSectors->WriteMemory(&isoDescriptor, sizeof(isoDescriptor), setEnd);
 	currentHeaderLBA += 2;
 
 	// Generate and write L-path table
@@ -1058,22 +1058,22 @@ void iso::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTIFIERS& id, con
 	auto sectorBuff = std::make_unique<unsigned char[]>(pathTableSize);
 
 	dirTree->GeneratePathTable( root, sectorBuff.get(), false );
-	auto lpathTable1 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors + ISOver, cd::IsoWriter::EdcEccForm::Form1);
-	lpathTable1->WriteMemory(sectorBuff.get(), pathTableSize);
+	auto lpathTable1 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors, cd::IsoWriter::EdcEccForm::Form1);
+	lpathTable1->WriteMemory(sectorBuff.get(), pathTableSize, setEnd);
 	currentHeaderLBA += pathTableSectors;
 
-	auto lpathTable2 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors + ISOver, cd::IsoWriter::EdcEccForm::Form1);
-	lpathTable2->WriteMemory(sectorBuff.get(), pathTableSize);
+	auto lpathTable2 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors, cd::IsoWriter::EdcEccForm::Form1);
+	lpathTable2->WriteMemory(sectorBuff.get(), pathTableSize, setEnd);
 	currentHeaderLBA += pathTableSectors;
 
 	// Generate and write M-path table
 	dirTree->GeneratePathTable( root, sectorBuff.get(), true );
-	auto mpathTable1 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors + ISOver, cd::IsoWriter::EdcEccForm::Form1);
-	mpathTable1->WriteMemory(sectorBuff.get(), pathTableSize);
+	auto mpathTable1 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors, cd::IsoWriter::EdcEccForm::Form1);
+	mpathTable1->WriteMemory(sectorBuff.get(), pathTableSize, setEnd);
 	currentHeaderLBA += pathTableSectors;
 
-	auto mpathTable2 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors + ISOver, cd::IsoWriter::EdcEccForm::Form1);
-	mpathTable2->WriteMemory(sectorBuff.get(), pathTableSize);
+	auto mpathTable2 = writer->GetSectorViewM2F1(currentHeaderLBA, pathTableSectors, cd::IsoWriter::EdcEccForm::Form1);
+	mpathTable2->WriteMemory(sectorBuff.get(), pathTableSize, setEnd);
 }
 
 unsigned char* iso::PathTableClass::GenTableData(unsigned char* buff, bool msb)

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -74,7 +74,7 @@ namespace iso
 		DirTreeClass* parent; // Non-owning
 		
 		/// Internal function for generating and writing directory records
-		bool WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& dir, const DIRENTRY& parentDir, const int totalDirs) const;
+		void WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& dir, const DIRENTRY& parentDir, const int totalDirs) const;
 
 		/// Internal function for recursive path table generation
 		std::unique_ptr<PathTableClass> GenPathTableSub(unsigned short& index, unsigned short parentIndex) const;
@@ -152,7 +152,7 @@ namespace iso
 		 *
 		 *	*writer	- Pointer to a cd::IsoWriter class that is ready for writing.
 		 */
-		bool WriteFiles(cd::IsoWriter* writer) const;
+		void WriteFiles(cd::IsoWriter* writer) const;
 
 		/**	Writes the file system of the directory records to a CD image. Execute this after the source files
 		 *	have been written to the CD image.
@@ -161,7 +161,7 @@ namespace iso
 		 *	root		   - Root directory
 		 *  totalDirs	   - Total number of directories. Only usefull for games built with the latest sony mastering tool
 		 */
-		bool WriteDirectoryRecords(cd::IsoWriter* writer, const DIRENTRY& root, int totalDirs);
+		void WriteDirectoryRecords(cd::IsoWriter* writer, const DIRENTRY& root, int totalDirs) const;
 
 		void SortDirectoryEntries(const bool byOrder, const bool byLBA = false);
 

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -51,7 +51,6 @@ namespace iso
 		struct PathEntry
 		{
 			std::string dir_id;
-			unsigned short dir_index = 0;
 			unsigned short dir_parent_index = 0;
 			int dir_lba = 0;
 		};

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -45,21 +45,21 @@ namespace iso
 	// EntryList must have stable references!
 	using EntryList = std::list<DIRENTRY>;
 	
-	class PathEntryClass {
-	public:
-		std::string dir_id;
-		unsigned short dir_index = 0;
-		unsigned short dir_parent_index = 0;
-		int dir_lba = 0;
-		
-		std::unique_ptr<class PathTableClass> sub;
-	};
-	
-	class PathTableClass {
+	class PathTableClass
+	{
+	private:
+		struct PathEntry
+		{
+			std::string dir_id;
+			unsigned short dir_index = 0;
+			unsigned short dir_parent_index = 0;
+			int dir_lba = 0;
+		};
+
 	public:
 		unsigned char* GenTableData(unsigned char* buff, bool msb);
 		
-		std::vector<PathEntryClass> entries;
+		std::vector<PathEntry> entries;
 	};
 
 	class DirTreeClass
@@ -71,9 +71,6 @@ namespace iso
 		
 		/// Internal function for generating and writing directory records
 		void WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY* parentDir, const int totalDirs) const;
-
-		/// Internal function for recursive path table generation
-		std::unique_ptr<PathTableClass> GenPathTableSub(unsigned short& index, unsigned short parentIndex) const;
 
 	public:
         static int GetAudioSize(const fs::path& audioFile);
@@ -125,13 +122,12 @@ namespace iso
 
 		/** Generates a path table of all directories and subdirectories within this class' directory record.
 		 *
-		 *  root	- Directory entry of this path
 		 *	*buff	- Pointer to a 2048 byte buffer to generate the path table to.
 		 *	msb		- If true, generates a path table encoded in big-endian format, little-endian otherwise.
 		 *
 		 *	Returns: Length of path table in bytes.
 		 */
-		int GeneratePathTable(const DIRENTRY& root, unsigned char* buff, bool msb) const;
+		int GeneratePathTable(unsigned char* buff, bool msb) const;
 
 		/** Adds a subdirectory to the directory record.
 		 *

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -65,16 +65,12 @@ namespace iso
 	class DirTreeClass
 	{
 	private:
-		// TODO: Once DirTreeClass stores a reference to its own entry, this will be pointless
-		// Same for all 'dir' arguments to methods of this class
-		std::string name;
+		DIRENTRY* m_entry; // Non-owning
 
-		DIRENTRY* entry = nullptr;
-
-		DirTreeClass* parent; // Non-owning
+		DirTreeClass* m_parent; // Non-owning
 		
 		/// Internal function for generating and writing directory records
-		void WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& dir, const DIRENTRY& parentDir, const int totalDirs) const;
+		void WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY* parentDir, const int totalDirs) const;
 
 		/// Internal function for recursive path table generation
 		std::unique_ptr<PathTableClass> GenPathTableSub(unsigned short& index, unsigned short parentIndex) const;
@@ -84,14 +80,14 @@ namespace iso
 		EntryList& entries; // List of all entries on the disc
 		std::vector<std::reference_wrapper<iso::DIRENTRY>> entriesInDir; // References to entries in this directory
 
-		DirTreeClass(EntryList& entries, DirTreeClass* parent = nullptr, std::string name = "<root>");
+		explicit DirTreeClass(EntryList& entries, DIRENTRY* entry = nullptr, DirTreeClass* parent = nullptr);
 		~DirTreeClass();
 
 		static DIRENTRY& CreateRootDirectory(EntryList& entries, const cd::ISO_DATESTAMP& volumeDate, const EntryAttributes& attributes);
 
-		void PrintRecordPath();
+		void PrintRecordPath() const;
 
-		void OutputHeaderListing(FILE* fp, int level) const;
+		void OutputHeaderListing(FILE* fp, const int level, const char* name) const;
 		
 		/** Calculates the length of the directory record to be produced by this class in bytes.
 		 *
@@ -158,10 +154,10 @@ namespace iso
 		 *	have been written to the CD image.
 		 *
 		 *	*writer		   - Pointer to a cd::IsoWriter class that is ready for writing.
-		 *	root		   - Root directory
-		 *  totalDirs	   - Total number of directories. Only usefull for games built with the latest sony mastering tool
 		 */
-		void WriteDirectoryRecords(cd::IsoWriter* writer, const DIRENTRY& root, int totalDirs) const;
+		void WriteDirectoryRecords(cd::IsoWriter* writer) const;
+
+		void WriteDescriptor(cd::IsoWriter* writer, const IDENTIFIERS& id, const int imageLen) const;
 
 		void SortDirectoryEntries(const bool byOrder, const bool byLBA = false);
 
@@ -175,8 +171,6 @@ namespace iso
 	};
 
 	void WriteLicenseData(cd::IsoWriter* writer, void* data, const bool& ps2);
-
-	void WriteDescriptor(cd::IsoWriter* writer, const IDENTIFIERS& id, const DIRENTRY& root, int imageLen);
 
 	const int DA_FILE_PLACEHOLDER_LBA = 0xDEADBEEF;
 

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -747,8 +747,7 @@ int Main(int argc, char* argv[])
 			global::trackNum++;
 		}
 
-		iso::DIRENTRY& root = entries.front();
-	    iso::DirTreeClass* dirTree = root.subdir.get();
+	    iso::DirTreeClass* dirTree = entries.front().subdir.get();
 
 		if ( !global::LBAfile.empty() )
 		{
@@ -774,12 +773,12 @@ int Main(int argc, char* argv[])
 				dirTree->SortDirectoryEntries(global::cdvd_style.value_or(false));
 				if (!unrefTracks.empty())
 				{
-					iso::DirTreeClass dirTree(unrefTracks, nullptr, "UNREFERENCED TRACKS");
+					iso::DirTreeClass tempTree(unrefTracks);
 					for (auto& entry : unrefTracks)
 					{
-						dirTree.entriesInDir.push_back(entry);
+						tempTree.entriesInDir.push_back(entry);
 					}
-					dirTree.OutputLBAlisting( fp, 0 );
+					tempTree.OutputLBAlisting( fp, 0 );
 				}
 
 				fclose( fp );
@@ -807,18 +806,18 @@ int Main(int argc, char* argv[])
 			{
 				dirTree->SortDirectoryEntries(false, true);
 
-				dirTree->OutputHeaderListing( fp, 0 );
+				dirTree->OutputHeaderListing( fp, 0, "<ROOT>" );
 
 				dirTree->SortDirectoryEntries(global::cdvd_style.value_or(false));
 				if (!unrefTracks.empty())
 				{
-					iso::DirTreeClass dirTree(unrefTracks, nullptr, "UNREFERENCED TRACKS");
+					iso::DirTreeClass tempTree(unrefTracks);
 					for (auto& entry : unrefTracks)
 					{
-						dirTree.entriesInDir.push_back(entry);
+						tempTree.entriesInDir.push_back(entry);
 					}
 					fprintf( fp, "\n" );
-					dirTree.OutputHeaderListing( fp, 1 );
+					tempTree.OutputHeaderListing( fp, 1, "UNREFERENCED TRACKS" );
 				}
 
 				fprintf( fp, "\n#endif\n" );
@@ -949,10 +948,10 @@ int Main(int argc, char* argv[])
 			}
 
 			// Write directory entries
-			dirTree->WriteDirectoryRecords( &writer, root, global::cdvd_style.value_or(false) ? dirTree->GetDirCountTotal() : 0 );
+			dirTree->WriteDirectoryRecords( &writer );
 
 			// Write file system descriptors to finish the image
-	        iso::WriteDescriptor( &writer, isoIdentifiers, root, totalLenLBA );
+	        dirTree->WriteDescriptor( &writer, isoIdentifiers, totalLenLBA );
 
 			if ( !global::QuietMode )
 			{

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -495,8 +495,6 @@ int Main(int argc, char* argv[])
 		std::vector<cdtrack> audioTracks;
 		iso::EntryList unrefTracks;
 
-		const tinyxml2::XMLElement* dataTrack = nullptr;
-
 		// Parse tracks
 		if ( !global::QuietMode )
 		{
@@ -529,7 +527,6 @@ int Main(int argc, char* argv[])
 			// Generate ISO file system for data track
 			if ( CompareICase( "data", track_type ) )
 			{
-				dataTrack = trackElement;
 				global::xa_edc = trackElement->BoolAttribute(xml::attrib::XA_EDC, true);
 
 				// This check is necessary so as to leave an empty value for compatibility with <=v2.04 dumped files timestamps

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -18,7 +18,7 @@ namespace global
 	bool	noXA		= false;
 	int		trackNum	= 1;
 
-	std::optional<bool> new_type;
+	std::optional<bool> cdvd_style;
 	std::optional<std::string> volid_override;
 	std::optional<fs::path> cuefile;
 	fs::path XMLscript;
@@ -274,6 +274,11 @@ int Main(int argc, char* argv[])
 		{
 			continue;
 		}
+		if (const char *new_type = modifyTrack->Attribute("new_type"); new_type != nullptr && modifyTrack->Attribute(xml::attrib::CDVD_STYLE) == nullptr)
+		{
+			modifyTrack->SetAttribute(xml::attrib::CDVD_STYLE, new_type);
+			modifyTrack->DeleteAttribute("new_type"); // new_type is deprecated
+		}
 		tinyxml2::XMLElement *dt =  modifyTrack->FirstChildElement(xml::elem::DIRECTORY_TREE);
 		if(dt == nullptr)
 		{
@@ -287,7 +292,7 @@ int Main(int argc, char* argv[])
 			if (const char *srcdir = scanElm->Attribute("srcdir"); srcdir != nullptr && scanElm->Attribute(xml::attrib::ENTRY_SOURCE) == nullptr)
 			{
 				scanElm->SetAttribute(xml::attrib::ENTRY_SOURCE, srcdir);
-				scanElm->DeleteAttribute("srcdir");
+				scanElm->DeleteAttribute("srcdir"); // srcdir is deprecated
 			}
 			if(CompareICase(scanElm->Name(), xml::elem::FILE))
 			{
@@ -530,13 +535,13 @@ int Main(int argc, char* argv[])
 				global::xa_edc = trackElement->BoolAttribute(xml::attrib::XA_EDC, true);
 
 				// This check is necessary so as to leave an empty value for compatibility with <=v2.04 dumped files timestamps
-				if ( trackElement->Attribute(xml::attrib::NEW_TYPE) != nullptr )
+				if ( trackElement->Attribute(xml::attrib::CDVD_STYLE) != nullptr )
 				{
-					global::new_type = trackElement->BoolAttribute(xml::attrib::NEW_TYPE);
+					global::cdvd_style = trackElement->BoolAttribute(xml::attrib::CDVD_STYLE);
 				}
 				if ( (global::ps2 = trackElement->BoolAttribute(xml::attrib::PS2)) )
 				{
-					global::new_type = true; // Force true if it's an PS2 disc
+					global::cdvd_style = true; // Force true if it's an PS2 disc
 				}
 
 				if ( global::trackNum != 1 )
@@ -715,7 +720,7 @@ int Main(int argc, char* argv[])
 
 				dirTree->OutputLBAlisting( fp, 0 );
 
-				dirTree->SortDirectoryEntries(global::new_type.value_or(false));
+				dirTree->SortDirectoryEntries(global::cdvd_style.value_or(false));
 				if (!unrefTracks.empty())
 				{
 					iso::DirTreeClass dirTree(unrefTracks, nullptr, "UNREFERENCED TRACKS");
@@ -753,7 +758,7 @@ int Main(int argc, char* argv[])
 
 				dirTree->OutputHeaderListing( fp, 0 );
 
-				dirTree->SortDirectoryEntries(global::new_type.value_or(false));
+				dirTree->SortDirectoryEntries(global::cdvd_style.value_or(false));
 				if (!unrefTracks.empty())
 				{
 					iso::DirTreeClass dirTree(unrefTracks, nullptr, "UNREFERENCED TRACKS");
@@ -893,7 +898,7 @@ int Main(int argc, char* argv[])
 			}
 
 			// Write directory entries
-			dirTree->WriteDirectoryRecords( &writer, root, global::new_type.value_or(false) ? dirTree->GetDirCountTotal() : 0 );
+			dirTree->WriteDirectoryRecords( &writer, root, global::cdvd_style.value_or(false) ? dirTree->GetDirCountTotal() : 0 );
 
 			// Write file system descriptors to finish the image
 	        iso::WriteDescriptor( &writer, isoIdentifiers, root, totalLenLBA );
@@ -1229,7 +1234,7 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 	const int rootLBA = 18+(GetSizeInSectors(pathTableLen)*4);
 
 	// Sort directory entries, calculate tree LBAs and retrieve size of image
-	dirTree->SortDirectoryEntries(global::new_type.value_or(false));
+	dirTree->SortDirectoryEntries(global::cdvd_style.value_or(false));
 	totalLen = dirTree->CalculateTreeLBA(rootLBA);
 
 	if ( !global::QuietMode )

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -1364,8 +1364,9 @@ static bool ParseFileEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElemen
 				return false;
 			}
 		}
+		/* Legend of Mana does not follow this rule.
 		if (dots == 0)
-			name += '.';
+			name += '.';*/
 	}
 
 	// ECMA-119 7.5.1 and 10.1 - File Identifier shall be 1-30 characters long plus one dot.

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -32,7 +32,7 @@ namespace global
 };
 
 
-bool ParseDirectory(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* parentElement, const fs::path& xmlPath, const EntryAttributes& parentAttribs, const fs::path& currentPath);
+bool ParseDirectory(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* parentElement, const fs::path& xmlPath, const EntryAttributes& defaultAttributes, const fs::path& currentPath);
 int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path& xmlPath, iso::EntryList& entries, iso::IDENTIFIERS& isoIdentifiers, int& totalLen);
 
 bool PackFileAsCDDA(void* buffer, const fs::path& audioFile);
@@ -1433,18 +1433,6 @@ static bool ParseFileEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElemen
 	return dirTree->AddFileEntry(std::move(name), entry, std::move(srcFile), ReadEntryAttributes(defaultAttributes, dirElement), trackid, dirElement->Attribute(xml::attrib::ENTRY_DATE));
 }
 
-static bool ParseDummyEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* dirElement)
-{
-	// TODO: For now this is a hack, unify this code again with the file type in the future
-	// so it isn't as awkward
-
-	dirTree->AddDummyEntry( dirElement->UnsignedAttribute(xml::attrib::NUM_DUMMY_SECTORS),
-							dirElement->UnsignedAttribute(xml::attrib::ENTRY_TYPE),
-							dirElement->UnsignedAttribute(xml::attrib::OFFSET),
-							dirElement->BoolAttribute(xml::attrib::ECC_ADDRES) );
-	return true;
-}
-
 static bool ParseDirEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* dirElement, const fs::path& xmlPath, const EntryAttributes& defaultAttributes, const fs::path& currentPath)
 {
 	fs::path srcDir;
@@ -1542,10 +1530,10 @@ bool ParseDirectory(iso::DirTreeClass* dirTree, const tinyxml2::XMLElement* pare
 		}
 		else if ( CompareICase( "dummy", dirElement->Name() ))
 		{
-			if (!ParseDummyEntry(dirTree, dirElement))
-			{
-				return false;
-			}
+			dirTree->AddDummyEntry( dirElement->UnsignedAttribute(xml::attrib::NUM_DUMMY_SECTORS),
+									dirElement->UnsignedAttribute(xml::attrib::ENTRY_TYPE),
+									dirElement->UnsignedAttribute(xml::attrib::OFFSET),
+									dirElement->BoolAttribute(xml::attrib::ECC_ADDRES) );
         }
 		else if ( CompareICase( "dir", dirElement->Name() ))
 		{

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -1607,7 +1607,7 @@ bool PackFileAsCDDA(void* buffer, const fs::path& audioFile)
 {
 	// open the decoder
 	ma_decoder decoder;
-	VirtualWavEx vw;
+	VirtualWav vw;
 	bool isLossy;
 	bool isPCM;
 	if(ma_redbook_decoder_init_path_by_ext(audioFile, &decoder, &vw, isLossy, isPCM) != MA_SUCCESS)

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -1,6 +1,5 @@
 #include "iso.h"		// ISO file system generator module
 #include "xml.h"
-#include <format>
 
 #define MA_NO_THREADING
 #define MA_NO_DEVICE_IO
@@ -336,14 +335,14 @@ int Main(int argc, char* argv[])
 							}
 						}
 
-						// Reuse or create track for this DA file
+						// Reuse or create ID for this DA file
 						const std::string trackid = [&]() -> std::string
 						{
 							if (const char* tid = scanElm->Attribute(xml::attrib::TRACK_ID); tid != nullptr && *tid != 0)
 							{
 								return updateAudioIndexFromTID(tid);
 							}
-							return std::format("{:02}", audioIndex++);
+							return std::to_string(100 + audioIndex++).substr(1);
 						}();
 
 						auto matchByID = audioTracks.end();
@@ -525,7 +524,7 @@ int Main(int argc, char* argv[])
 					return EXIT_FAILURE;
 				}
 
-				cuefp = OpenScopedFile( global::cuefile.value(), "w" );
+				cuefp = OpenScopedFile( *global::cuefile, "w" );
 
 				if ( cuefp == nullptr )
 				{
@@ -1352,7 +1351,7 @@ static bool ParseFileEntry(iso::DirTreeClass* dirTree, const tinyxml2::XMLElemen
 					return false;
 				}
 			}
-        	else if (isalnum((unsigned char)ch))
+			else if (isalnum((unsigned char)ch))
 			{
 				ch = std::toupper((unsigned char)ch);
 			}

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -1,5 +1,6 @@
 #include "iso.h"		// ISO file system generator module
 #include "xml.h"
+#include <format>
 
 #define MA_NO_THREADING
 #define MA_NO_DEVICE_IO
@@ -44,7 +45,7 @@ bool UpdateDAFilesWithLBA(iso::EntryList& entries, const char *trackid, const un
 		if(entry.trackid != trackid) continue;
 		if(entry.lba != iso::DA_FILE_PLACEHOLDER_LBA)
 		{
-			printf( "ERROR: Cannot replace entry.lba when it is not 0x%X\n ", iso::DA_FILE_PLACEHOLDER_LBA);
+			printf( "ERROR: Cannot replace entry.lba for trackid=\"%s\" when it is not 0x%X\n", entry.trackid.c_str(), iso::DA_FILE_PLACEHOLDER_LBA);
 			return false;
 		}
 		entry.lba = lba;
@@ -262,21 +263,32 @@ int Main(int argc, char* argv[])
 		}
     }
 
-	// Fix XML tree to our current spec
+	// Check if there is an <iso_project> element
+	const tinyxml2::XMLElement* projectElement = xmlFile.FirstChildElement(xml::elem::ISO_PROJECT);
+	if ( projectElement == nullptr )
+	{
+		printf( "ERROR: Cannot find <iso_project> element in XML document.\n" );
+		return EXIT_FAILURE;
+	}
+
+	// Fix old XML trees to our current spec
 	// convert DA file source syntax to DA file trackid syntax
-	unsigned trackindex = 2;
 	for(tinyxml2::XMLElement *modifyProject = xmlFile.FirstChildElement(xml::elem::ISO_PROJECT);
 		modifyProject != nullptr;
 		modifyProject = modifyProject->NextSiblingElement(xml::elem::ISO_PROJECT))
 	{
+		unsigned audioIndex = 0;
 		tinyxml2::XMLElement *modifyTrack = modifyProject->FirstChildElement(xml::elem::TRACK);
 		if((modifyTrack == nullptr) || (!modifyTrack->Attribute(xml::attrib::TRACK_TYPE, "data")))
 		{
 			continue;
 		}
-		if (const char *new_type = modifyTrack->Attribute("new_type"); new_type != nullptr && modifyTrack->Attribute(xml::attrib::CDVD_STYLE) == nullptr)
+		if (const char *new_type = modifyTrack->Attribute("new_type"); new_type != nullptr)
 		{
-			modifyTrack->SetAttribute(xml::attrib::CDVD_STYLE, new_type);
+			if (modifyTrack->Attribute(xml::attrib::CDVD_STYLE) == nullptr)
+			{
+				modifyTrack->SetAttribute(xml::attrib::CDVD_STYLE, new_type);
+			}
 			modifyTrack->DeleteAttribute("new_type"); // new_type is deprecated
 		}
 		tinyxml2::XMLElement *dt =  modifyTrack->FirstChildElement(xml::elem::DIRECTORY_TREE);
@@ -284,33 +296,84 @@ int Main(int argc, char* argv[])
 		{
 			continue;
 		}
+		std::vector<std::tuple<tinyxml2::XMLElement *, std::string_view, std::string_view>> audioTracks;
 		std::queue<tinyxml2::XMLElement *> toscan({dt});
 		while(!toscan.empty())
 		{
 			tinyxml2::XMLElement *scanElm = toscan.front();
 			toscan.pop();
-			if (const char *srcdir = scanElm->Attribute("srcdir"); srcdir != nullptr && scanElm->Attribute(xml::attrib::ENTRY_SOURCE) == nullptr)
+			if (const char *srcdir = scanElm->Attribute("srcdir"); srcdir != nullptr)
 			{
-				scanElm->SetAttribute(xml::attrib::ENTRY_SOURCE, srcdir);
+				if (scanElm->Attribute(xml::attrib::ENTRY_SOURCE) == nullptr)
+				{
+					scanElm->SetAttribute(xml::attrib::ENTRY_SOURCE, srcdir);
+				}
 				scanElm->DeleteAttribute("srcdir"); // srcdir is deprecated
 			}
 			if(CompareICase(scanElm->Name(), xml::elem::FILE))
 			{
 				if(scanElm->Attribute(xml::attrib::ENTRY_TYPE, "da"))
 				{
-					const char *trackid = scanElm->Attribute(xml::attrib::TRACK_ID);
 					const char *source = scanElm->Attribute(xml::attrib::ENTRY_SOURCE);
-					if((trackid != nullptr) && (source != nullptr))
+					if(source != nullptr && *source != 0)
 					{
-						printf( "ERROR: Cannot specify trackid and source at the same time\n ");
-		                return EXIT_FAILURE;
-					}
-					if(source != nullptr)
-					{
-						char tid[3];
-						snprintf(tid, sizeof(tid), "%02u", trackindex);
-						std::string trackid = tid;
-						trackindex++;
+						auto updateAudioIndexFromTID = [&](const char *tid) -> const char*
+						{
+							if (int id = atoi(tid); audioIndex <= id)
+							{
+								audioIndex = id + 1;
+							}
+							return tid;
+						};
+
+						// Index existing tracks only once
+						if (audioIndex == 0)
+						{
+							for (tinyxml2::XMLElement *t = modifyTrack->NextSiblingElement(xml::elem::TRACK); t != nullptr; t = t->NextSiblingElement(xml::elem::TRACK))
+							{
+								const char* tid = t->Attribute(xml::attrib::TRACK_ID);
+								const char* src = t->Attribute(xml::attrib::TRACK_SOURCE);
+								audioTracks.emplace_back(t, tid ? updateAudioIndexFromTID(tid) : "", src ? src : "");
+							}
+						}
+
+						// Reuse or create track for this DA file
+						const std::string trackid = [&]() -> std::string
+						{
+							if (const char* tid = scanElm->Attribute(xml::attrib::TRACK_ID); tid != nullptr && *tid != 0)
+							{
+								return updateAudioIndexFromTID(tid);
+							}
+							return std::format("{:02}", audioIndex++);
+						}();
+
+						auto matchByID = audioTracks.end();
+						std::string_view sourceSV = source;
+						for (auto it = audioTracks.begin(); it != audioTracks.end(); ++it)
+						{
+							auto& [t, tid, src] = *it;
+							// reuse track with same source if possible
+							if (src == sourceSV)
+							{
+								modifyTrack = t;
+								modifyTrack->SetAttribute(xml::attrib::TRACK_ID, trackid.c_str());
+								audioTracks.erase(it);
+								goto update_file;
+							}
+							if (tid == trackid)
+							{
+								matchByID = it;
+							}
+						}
+
+						// reuse track with same ID if source not matched
+						if (matchByID != audioTracks.end())
+						{
+							modifyTrack = std::get<0>(*matchByID);
+							modifyTrack->SetAttribute(xml::attrib::TRACK_SOURCE, source);
+							audioTracks.erase(matchByID);
+							goto update_file;
+						}{
 
                         // add a new track
 						tinyxml2::XMLElement *newtrack = xmlFile.NewElement(xml::elem::TRACK);
@@ -323,7 +386,7 @@ int Main(int argc, char* argv[])
 						modifyProject->InsertAfterChild(modifyTrack, newtrack);
 						modifyTrack = newtrack;
 
-						// update the file to point to the track
+						}update_file: // update the file to point to the track
 						scanElm->DeleteAttribute(xml::attrib::ENTRY_SOURCE);
 						scanElm->SetAttribute(xml::attrib::TRACK_ID, trackid.c_str());
 					}
@@ -365,18 +428,7 @@ int Main(int argc, char* argv[])
 	    return EXIT_SUCCESS;
 	}
 
-	// Check if there is an <iso_project> element
-    const tinyxml2::XMLElement* projectElement =
-		xmlFile.FirstChildElement(xml::elem::ISO_PROJECT);
-
-    if ( projectElement == nullptr )
-	{
-		printf( "ERROR: Cannot find <iso_project> element in XML document.\n" );
-		return EXIT_FAILURE;
-    }
-
     int imagesCount = 0;
-
 	// Build loop for XML scripts with multiple <iso_project> elements
 	while ( projectElement != nullptr )
 	{

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -1020,12 +1020,9 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 		trackElement->FirstChildElement(xml::elem::IDENTIFIERS);
 
 	// Set file system identifiers
-
 	if ( identifierElement != nullptr )
 	{
-		const char* identifierFile;
-		
-		// Otherwise use individual elements defined by each attribute
+		// Use individual elements defined by each attribute
 		isoIdentifiers.SystemID		= identifierElement->Attribute(xml::attrib::SYSTEM_ID);
 		isoIdentifiers.VolumeID		= identifierElement->Attribute(xml::attrib::VOLUME_ID);
 		isoIdentifiers.VolumeSet	= identifierElement->Attribute(xml::attrib::VOLUME_SET);
@@ -1037,7 +1034,7 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 		isoIdentifiers.ModificationDate = identifierElement->Attribute(xml::attrib::MODIFICATION_DATE);
 
 		// Is an ID file specified?
-		if( (identifierFile = identifierElement->Attribute(xml::attrib::ID_FILE)) )
+		if( const char* identifierFile = identifierElement->Attribute(xml::attrib::ID_FILE) )
 		{
 			// Load the file as an XML document
 			{
@@ -1100,7 +1097,9 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 					isoIdentifiers.ModificationDate = str;
 			}
 		}
+	}
 
+	{ // Set default identifiers if not present
 		bool hasSystemID = true;
 		if ( isoIdentifiers.SystemID == nullptr )
 		{

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -170,7 +170,6 @@ int Main(int argc, char* argv[])
 			if (auto output = ParsePathArgument(args, "L", "license"); output.has_value())
 			{
 				global::LicenseFile = output->lexically_normal();
-				OutputOverride = true;
 				continue;
 			}
 			if (auto newxmlfile = ParsePathArgument(args, "rebuildxml"); newxmlfile.has_value())
@@ -435,7 +434,7 @@ int Main(int argc, char* argv[])
 		imagesCount++;
 		if ( imagesCount > 1 && OutputOverride )
 		{
-			printf( "ERROR: -o/-c/-L switches cannot be used in a multi-disc ISO "
+			printf( "ERROR: -o or -c switches cannot be used in a multi-disc ISO "
 				"project.\n" );
 			return EXIT_FAILURE;
 		}

--- a/src/mkpsxiso/miniaudio_helpers.h
+++ b/src/mkpsxiso/miniaudio_helpers.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#ifdef __cplusplus
 #include "miniaudio_pcm.h"
 
-ma_result ma_decoder_init_path(const fs::path& pFilePath, const ma_decoder_config* pConfig, ma_decoder* pDecoder);
-
-ma_result ma_redbook_decoder_init_path_by_ext(const fs::path& filePath, ma_decoder* pDecoder, VirtualWavEx* vw, bool& isLossy, bool& isPCM);
+ma_result ma_redbook_decoder_init_path_by_ext(const fs::path& filePath, ma_decoder* pDecoder, VirtualWav* vw, bool& isLossy, bool& isPCM);
 
 #if defined(MINIAUDIO_IMPLEMENTATION) || defined(MA_IMPLEMENTATION)
 
@@ -27,7 +24,7 @@ typedef enum {
 } DecoderAudioFormats;
 
 // Helper wrapper to open as redbook (44100kHz stereo s16le) audio and use the file extension to determine the order to try decoders
-inline ma_result ma_redbook_decoder_init_path_by_ext(const fs::path& filePath, ma_decoder* pDecoder, VirtualWavEx* vw, bool& isLossy, bool& isPCM)
+inline ma_result ma_redbook_decoder_init_path_by_ext(const fs::path& filePath, ma_decoder* pDecoder, VirtualWav* vw, bool& isLossy, bool& isPCM)
 {
 	ma_decoder_config decoderConfig = ma_decoder_config_init(ma_format_s16, 2, 44100);	
 	isLossy = false;
@@ -103,7 +100,5 @@ inline ma_result ma_redbook_decoder_init_path_by_ext(const fs::path& filePath, m
 	}
 	return MA_SUCCESS;
 }
-
-#endif
 
 #endif

--- a/src/mkpsxiso/miniaudio_pcm.h
+++ b/src/mkpsxiso/miniaudio_pcm.h
@@ -39,7 +39,6 @@ static ma_result virtual_wav_read(ma_decoder *pDecoder, void *pBufferOut, size_t
 
 static ma_result virtual_wav_seek(ma_decoder *pDecoder, ma_int64 byteOffset, ma_seek_origin origin)
 {
-    int result;
     VirtualWav *vw = (VirtualWav *)pDecoder->pUserData;
 
     if (origin == ma_seek_origin_end)

--- a/src/mkpsxiso/miniaudio_pcm.h
+++ b/src/mkpsxiso/miniaudio_pcm.h
@@ -4,9 +4,9 @@
 
 typedef struct {
     uint8_t header[44];
-    uint64_t pos;   // actual file position
-    uint64_t vpos;  // virtual file position
-    uint64_t vsize; // virtual file size
+    int64_t pos;   // actual file position
+    int64_t vpos;  // virtual file position
+    int64_t vsize; // virtual file size
     FILE *file;
 } VirtualWav;
 
@@ -73,7 +73,7 @@ static ma_result virtual_wav_seek(ma_decoder *pDecoder, ma_int64 byteOffset, ma_
         if((byteOffset+vw->vpos) > vw->vsize) return MA_ERROR;
         if((byteOffset+vw->vpos) < 0) return MA_ERROR;
         vw->vpos += byteOffset;
-        uint64_t abspos = vw->pos + byteOffset;
+        int64_t abspos = vw->pos + byteOffset;
         if(abspos < 0)
         {
             byteOffset = -vw->pos;
@@ -95,7 +95,7 @@ static ma_result virtual_wav_seek(ma_decoder *pDecoder, ma_int64 byteOffset, ma_
             return MA_ERROR;
         }
 
-        result = fseek(vw->file, (int)byteOffset, whence);
+        result = fseek(vw->file, (long)byteOffset, whence);
     #endif
 #else
     result = fseek(vw->file, (long)byteOffset, whence);

--- a/src/mkpsxiso/miniaudio_pcm.h
+++ b/src/mkpsxiso/miniaudio_pcm.h
@@ -51,54 +51,39 @@ static ma_result virtual_wav_read(ma_decoder *pDecoder, void *pBufferOut, size_t
 
 static ma_result virtual_wav_seek(ma_decoder *pDecoder, ma_int64 byteOffset, ma_seek_origin origin)
 {
-    int whence;
     int result;
     VirtualWav *vw = (VirtualWav *)pDecoder->pUserData;
 
-    if (origin == ma_seek_origin_start) {
-        if(byteOffset < 0) return MA_ERROR;
-        if(byteOffset > vw->vsize) return MA_ERROR;
-        vw->vpos = byteOffset;
-        byteOffset = ma_dr_wav_max(byteOffset - 44, 0);
-        vw->pos = byteOffset;
-        whence = SEEK_SET;
-    } else if (origin == ma_seek_origin_end) {
-        if(byteOffset > 0) return MA_ERROR;
-        if((byteOffset + vw->vsize) < 0) return MA_ERROR;
-        vw->vpos = vw->vsize + byteOffset;
-        byteOffset = ma_dr_wav_max(byteOffset, -(vw->vsize - 44));
-        vw->pos = (vw->vsize - 44) + byteOffset;
-        whence = SEEK_END;
-    } else {
-        if((byteOffset+vw->vpos) > vw->vsize) return MA_ERROR;
-        if((byteOffset+vw->vpos) < 0) return MA_ERROR;
-        vw->vpos += byteOffset;
-        int64_t abspos = vw->pos + byteOffset;
-        if(abspos < 0)
-        {
-            byteOffset = -vw->pos;
-        }
-        else if(abspos > (vw->vsize-44))
-        {
-            byteOffset = (vw->vsize-44) - vw->pos;
-        }
-        vw->pos += byteOffset;
-        whence = SEEK_CUR;
+    if (origin == ma_seek_origin_end)
+    {
+        byteOffset += vw->vsize;
     }
+    else if (origin == ma_seek_origin_current)
+    {
+        byteOffset += vw->vpos;
+    }
+
+    if (byteOffset < 0 || byteOffset > vw->vsize)
+    {
+        return MA_ERROR;
+    }
+
+    vw->vpos = byteOffset;
+    vw->pos  = ma_dr_wav_max(byteOffset - 44, 0);
 
 #if defined(_WIN32)
     #if (defined(_MSC_VER) && _MSC_VER > 1200) || defined(__MINGW64__)
-        result = _fseeki64(vw->file, byteOffset, whence);
+        result = _fseeki64(vw->file, vw->pos, SEEK_SET);
     #else
         /* No _fseeki64() so restrict to 31 bits. */
-        if (byteOffset > 0x7FFFFFFF) {
+        if (vw->pos > 0x7FFFFFFF) {
             return MA_ERROR;
         }
 
-        result = fseek(vw->file, (long)byteOffset, whence);
+        result = fseek(vw->file, (long)vw->pos, SEEK_SET);
     #endif
 #else
-    result = fseek(vw->file, (long)byteOffset, whence);
+    result = fseek(vw->file, (long)vw->pos, SEEK_SET);
 #endif
     if (result != 0) {
         return MA_ERROR;

--- a/src/mkpsxiso/miniaudio_pcm.h
+++ b/src/mkpsxiso/miniaudio_pcm.h
@@ -71,21 +71,8 @@ static ma_result virtual_wav_seek(ma_decoder *pDecoder, ma_int64 byteOffset, ma_
     vw->vpos = byteOffset;
     vw->pos  = ma_dr_wav_max(byteOffset - 44, 0);
 
-#if defined(_WIN32)
-    #if (defined(_MSC_VER) && _MSC_VER > 1200) || defined(__MINGW64__)
-        result = _fseeki64(vw->file, vw->pos, SEEK_SET);
-    #else
-        /* No _fseeki64() so restrict to 31 bits. */
-        if (vw->pos > 0x7FFFFFFF) {
-            return MA_ERROR;
-        }
-
-        result = fseek(vw->file, (long)vw->pos, SEEK_SET);
-    #endif
-#else
-    result = fseek(vw->file, (long)vw->pos, SEEK_SET);
-#endif
-    if (result != 0) {
+    if (SeekFile(vw->file, vw->pos, SEEK_SET) != 0)
+    {
         return MA_ERROR;
     }
 

--- a/src/mkpsxiso/miniaudio_pcm.h
+++ b/src/mkpsxiso/miniaudio_pcm.h
@@ -1,27 +1,15 @@
 #pragma once
-#include "common.h"
+
 #include "miniaudio.h"
+#include "platform.h"
 
 typedef struct {
     uint8_t header[44];
     int64_t pos;   // actual file position
     int64_t vpos;  // virtual file position
     int64_t vsize; // virtual file size
-    FILE *file;
+    unique_file file;
 } VirtualWav;
-
-MA_API ma_result ma_decoder_init_FILE_pcm(FILE *file, ma_decoder_config* pConfig, ma_decoder* pDecoder, VirtualWav *pUserData);
-
-#ifdef __cplusplus
-#include "platform.h"
-
-class VirtualWavEx : public VirtualWav {
-    public:
-    unique_file pcmFp;
-};
-
-MA_API ma_result ma_decoder_init_path_pcm(const fs::path& pFilePath, ma_decoder_config* pConfig, ma_decoder* pDecoder, VirtualWavEx *pUserData);
-#endif
 
 #if defined(MINIAUDIO_IMPLEMENTATION) || defined(MA_IMPLEMENTATION)
 
@@ -40,7 +28,7 @@ static ma_result virtual_wav_read(ma_decoder *pDecoder, void *pBufferOut, size_t
     }
     if(bytesToRead > 0)
     {
-        const size_t actualread = fread(pBufferOut, 1, bytesToRead, vw->file);
+        const size_t actualread = fread(pBufferOut, 1, bytesToRead, vw->file.get());
         bytesRead += actualread;
         vw->vpos += actualread;
         vw->pos += actualread;
@@ -71,7 +59,7 @@ static ma_result virtual_wav_seek(ma_decoder *pDecoder, ma_int64 byteOffset, ma_
     vw->vpos = byteOffset;
     vw->pos  = ma_dr_wav_max(byteOffset - 44, 0);
 
-    if (SeekFile(vw->file, vw->pos, SEEK_SET) != 0)
+    if (SeekFile(vw->file.get(), vw->pos, SEEK_SET) != 0)
     {
         return MA_ERROR;
     }
@@ -105,10 +93,17 @@ static ma_result stdio_file_size(FILE *file, uint64_t *pSizeInBytes)
     return MA_SUCCESS;
 }
 
-inline MA_API ma_result ma_decoder_init_FILE_pcm(FILE *file, ma_decoder_config* pConfig, ma_decoder* pDecoder, VirtualWav *pUserData)
+// feed to miniaudio as a wav file
+inline MA_API ma_result ma_decoder_init_path_pcm(const fs::path& pFilePath, ma_decoder_config* pConfig, ma_decoder* pDecoder, VirtualWav *pUserData)
 {
+    pUserData->file.reset(OpenFile(pFilePath, "rb"));
+    if(!pUserData->file)
+    {
+        return MA_INVALID_FILE;
+    }
+
     uint64_t pcmSize;
-    if(stdio_file_size(file, &pcmSize) != MA_SUCCESS)
+    if(stdio_file_size(pUserData->file.get(), &pcmSize) != MA_SUCCESS)
     {
         return MA_ERROR;
     }
@@ -157,7 +152,7 @@ inline MA_API ma_result ma_decoder_init_FILE_pcm(FILE *file, ma_decoder_config* 
     pUserData->header[29] = (uint8_t)(byteRate >> 8);
     pUserData->header[30] = byteRate >> 16;
     pUserData->header[31] = byteRate >> 24;
-    const uint16_t blockalign = numchannels * (bitspersample/8);;
+    const uint16_t blockalign = numchannels * (bitspersample/8);
     pUserData->header[32] = blockalign;
     pUserData->header[33] = blockalign >> 8;
     pUserData->header[34] = bitspersample;
@@ -168,32 +163,8 @@ inline MA_API ma_result ma_decoder_init_FILE_pcm(FILE *file, ma_decoder_config* 
     pUserData->header[42] = pcmSize >> 16;
     pUserData->header[43] = pcmSize >> 24;
 
-    pUserData->file = file;
-
     pConfig->encodingFormat = ma_encoding_format_wav;
-    if(ma_decoder_init(&virtual_wav_read, &virtual_wav_seek, pUserData, pConfig, pDecoder) != MA_SUCCESS)
-    {
-        return MA_ERROR;
-    }
-
-    return MA_SUCCESS;
+    return ma_decoder_init(&virtual_wav_read, &virtual_wav_seek, pUserData, pConfig, pDecoder);
 }
-#ifdef __cplusplus
-// feed to pcm file to miniaudio as a wav file
-inline MA_API ma_result ma_decoder_init_path_pcm(const fs::path& pFilePath, ma_decoder_config* pConfig, ma_decoder* pDecoder, VirtualWavEx *pUserData)
-{
-    unique_file file(OpenFile(pFilePath, "rb"));
-    if(!file)
-    {
-        return MA_INVALID_FILE;
-    }
-    if(ma_decoder_init_FILE_pcm(file.get(), pConfig, pDecoder, pUserData) != MA_SUCCESS)
-    {
-        return MA_NO_BACKEND;
-    }
-    pUserData->pcmFp = std::move(file);
-    return MA_SUCCESS;
-}
-#endif
 
 #endif

--- a/src/shared/cd.h
+++ b/src/shared/cd.h
@@ -12,6 +12,10 @@
 // CD and ISO 9660 reader namespace
 namespace cd {
 
+	// Set struct alignment to 1 because the ISO file system is not very memory alignment friendly which will
+	// result to alignment issues when reading data entries with structs.
+	#pragma pack(push, 1)
+
 	/// Structure for a mode 2 form 1 sector (used in regular files)
 	typedef struct {
 		unsigned char	sync[12];	/// Sync pattern (usually 00 FF FF FF FF FF FF FF FF FF FF 00)
@@ -51,10 +55,6 @@ namespace cd {
 		unsigned char	data[2324];	/// Data (form 2)
 		unsigned char	edc[4];		/// Error-detection code (CRC32 of data area)
 	} SECTOR_M2F2;
-
-	// Set struct alignment to 1 because the ISO file system is not very memory alignment friendly which will
-	// result to alignment issues when reading data entries with structs.
-	#pragma pack(push, 1)
 
 	/// Structure of a double-endian unsigned short word
 	typedef struct {

--- a/src/shared/cd.h
+++ b/src/shared/cd.h
@@ -107,7 +107,7 @@ namespace cd {
 		unsigned char	identifierLen;	/// Length of Directory Identifier(LEN_DI) (or 1 for the root directory)
 		unsigned char	extLength;		/// Number of sectors in Extended Attribute Record
 		unsigned int	dirOffs;		/// Number of the first sector in the directory, as a double word
-		short			parentDirIndex;	/// Index of the directory record's parent directory
+		unsigned short	parentDirIndex;	/// Index of the directory record's parent directory
 		// If identifierLen is odd numbered, a padding byte will be present after the identifier text.
 	};
 

--- a/src/shared/common.cpp
+++ b/src/shared/common.cpp
@@ -102,7 +102,7 @@ std::string LongDateToString(const cd::ISO_LONG_DATESTAMP& src)
 
 uint32_t GetSizeInSectors(uint64_t size, uint32_t sectorSize)
 {
-	return size ? static_cast<uint32_t>((size + (sectorSize - 1)) / sectorSize) : 1;
+	return size ? static_cast<uint32_t>((size - 1) / sectorSize + 1) : 1;
 }
 
 int32_t TimecodeToSectors(const std::string_view timecode)

--- a/src/shared/common.h
+++ b/src/shared/common.h
@@ -52,7 +52,7 @@ public:
 // Shared by mkpsxiso and dumpsxiso
 namespace global
 {
-	extern std::optional<bool> new_type;
+	extern std::optional<bool> cdvd_style;
 }
 
 // Helper functions for datestamp manipulation

--- a/src/shared/platform.cpp
+++ b/src/shared/platform.cpp
@@ -63,6 +63,15 @@ FILE* OpenFile(const fs::path& path, const char* mode)
 #endif
 }
 
+int SeekFile(FILE *file, int64_t offset, int origin)
+{
+#ifdef _WIN32
+	return _fseeki64(file, offset, origin);
+#else
+	return fseeko(file, offset, origin);
+#endif
+}
+
 std::optional<struct stat64> Stat(const fs::path& path)
 {
 	struct stat64 fileAttrib;

--- a/src/shared/platform.cpp
+++ b/src/shared/platform.cpp
@@ -195,7 +195,7 @@ int wmain(int argc, wchar_t* argv[])
 	}
 
 	std::vector<char*> u8argv;
-	u8Arguments.reserve(argc + 1);
+	u8argv.reserve(argc + 1);
 	for (std::string& str : u8Arguments)
 	{
 		u8argv.emplace_back(str.data());

--- a/src/shared/platform.cpp
+++ b/src/shared/platform.cpp
@@ -7,7 +7,7 @@
 #include <windows.h>
 #include <vector>
 #else
-#include <fcntl.h>
+#include <sys/time.h>
 #endif
 
 #ifdef _WIN32
@@ -170,12 +170,11 @@ void UpdateTimestamps(const fs::path& path, const cd::ISO_DATESTAMP& entryDate)
 		CloseHandle(hFile);
 	}
 #else
-	struct timespec times[2];
-	times[0].tv_nsec = UTIME_OMIT;
-
+	struct timeval times[2]{};
+	times[0].tv_sec = time;
 	times[1].tv_sec = time;
-	times[1].tv_nsec = 0;
-	if(0 != utimensat(AT_FDCWD, path.c_str(), times, 0))
+
+	if(0 != utimes(path.c_str(), times))
 	{
 		printf("ERROR: unable to update timestamps for %s\n", path.string().c_str());
 	}

--- a/src/shared/platform.h
+++ b/src/shared/platform.h
@@ -10,10 +10,9 @@
 #else
 #include <sys/stat.h>
 #define SYSTEM_TIMEZONE timezone
-#if (defined(__APPLE__) && defined(__arm64__)) || (defined(__linux__) && defined(__aarch64__))
-// __DARWIN_ONLY_64_BIT_INO_T is set on ARM-based Macs (which then sets __DARWIN_64_BIT_INO_T).
-// This sets the following in Apple SDK's stat.h: struct stat __DARWIN_STRUCT_STAT64;
-// So use stat over stat64 for ARM-based Macs (ARM-based Linux behaves the same)
+#if defined(__APPLE__) || (defined(__linux__) && defined(__aarch64__))
+// Apple uses 64-bit stat by default since macOS 10.6 on all architectures.
+// AArch64 Linux was built as a 64-bit system by default and also lacks stat64.
 #define stat64 stat
 #endif
 #endif

--- a/src/shared/platform.h
+++ b/src/shared/platform.h
@@ -19,6 +19,7 @@
 #endif
 
 FILE* OpenFile(const fs::path& path, const char* mode);
+int SeekFile(FILE *file, int64_t offset, int origin);
 std::optional<struct stat64> Stat(const fs::path& path);
 int64_t GetSize(const fs::path& path);
 void UpdateTimestamps(const fs::path& path, const cd::ISO_DATESTAMP& entryDate);

--- a/src/shared/xml.h
+++ b/src/shared/xml.h
@@ -26,7 +26,7 @@ namespace attrib
 
 	constexpr const char* TRACK_TYPE = "type";
 	constexpr const char* XA_EDC = "xa_edc";
-	constexpr const char* NEW_TYPE = "new_type";
+	constexpr const char* CDVD_STYLE = "cdvd_style";
 	constexpr const char* PS2 = "ps2";
 	constexpr const char* TRACK_SOURCE = "source";
 	constexpr const char* TRACK_ID = "trackid";


### PR DESCRIPTION
This PR introduces several code improvements and a necessary terminology update:

- **Refactored Logic:** Unified the sector reading logic in `ReadBytes` and simplified `virtual_wav_seek` to reduce complexity and code duplication. Also removed redundant validation checks and redundant return values in writer functions.

- **Global IsoReader:** Moved `IsoReader` to the global scope. Since this instance is utilized in practically every function of the program, making it global simplifies the code structure and will make implementing future changes much easier.

- **Attribute Rename (`new_type` -> `cdvd_style`):** The previous attribute name `new_type` was too vague. I've renamed it to `cdvd_style` to accurately reflect that this setting handles the logic specific to the **Sony CD/DVD Generator** engine.
    - _Note: I am open to suggestions for a better name._

This PR depends on:
- #71