### PR TITLE
Add source path to mydir in example.xml

### DIFF
--- a/examples/example.xml
+++ b/examples/example.xml
@@ -125,7 +125,7 @@
 					order	- Optional, custom Directory Record order (see above for description).
 						  
 			-->
-			<dir name="mydir">
+			<dir name="mydir" source="../mkpsxiso/mydir">
 			
 				<!-- All <file> and <dir> elements here will be inside mydir -->
 				


### PR DESCRIPTION
Helps users understand why the warning 'source' attribute for subdirectory 'STR' is invalid or empty may occur.