### PR TITLE
Pin Windows CI runner to 2022 to maintain pre-Win10 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,9 @@ on:   [ push, pull_request ]
 jobs:
   build-windows:
     name:    Build mkpsxiso on Windows
-    runs-on: windows-latest
+    # TODO: Implement dynamic installation of the v143 toolset on windows-latest
+    # once GitHub completely drops support for the windows-2022 runner.
+    runs-on: windows-2022
 
     steps:
     - name: Fetch repo contents


### PR DESCRIPTION
Last month GitHub migrated from Visual Studio 2022 to Visual Studio 2026 on the Windows Server 2025 runner.

VS2026 dropped support for pre-Win10 systems, meaning compiled binaries may or may not work on older OS versions. 

I tested on Win7 and `mkpsxiso` works fine but `dumpsxiso` doesn't. It crashes due to lack of `CreateFile2` API.
`dumpsxiso` relies on `std::filesystem` methods like `is_directory`, `create_directories`, and `directory_iterator` which now internally require `CreateFile2` under MSVC 2026.

If we want to maintain compatibility, we need to either stick with VS2022 or manually rewrite those STL function calls.