### PR TITLE
Preserve root directory entry date and PVD abstract/bibliographic identifiers

### DIFF
--- a/src/dumpsxiso/xmlwriter.cpp
+++ b/src/dumpsxiso/xmlwriter.cpp
@@ -180,6 +180,10 @@ static tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry
 			{
 				newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, reinterpret_cast<const char*>(sourcePath.generic_u8string().c_str()));
 			}
+			if (!param::dir)
+			{
+				newelement->SetAttribute(xml::attrib::ENTRY_DATE, DateToString(entry.entry.entryDate, false).c_str());
+			}
 		}
 
 		dirElement = newelement;
@@ -389,6 +393,8 @@ unsigned xml::WriteXML(const cd::ISO_DESCRIPTOR& descriptor, const std::unique_p
 		setAttributeIfNotEmpty(xml::attrib::PUBLISHER, CleanDescElement(descriptor.publisherIdentifier));
 		setAttributeIfNotEmpty(xml::attrib::DATA_PREPARER, CleanDescElement(descriptor.dataPreparerIdentifier));
 		setAttributeIfNotEmpty(xml::attrib::COPYRIGHT, CleanDescElement(descriptor.copyrightFileIdentifier));
+		setAttributeIfNotEmpty(xml::attrib::ABSTRACT_FILE, CleanDescElement(descriptor.abstractFileIdentifier));
+		setAttributeIfNotEmpty(xml::attrib::BIBLIOGRAPHIC_FILE, CleanDescElement(descriptor.bibliographicFilelIdentifier));
 		setAttributeIfNotEmpty(xml::attrib::CREATION_DATE, LongDateToString(descriptor.volumeCreateDate).c_str());
 		if (auto ZERO_DATE = GetUnspecifiedLongDate(); memcmp(&descriptor.volumeModifyDate, &ZERO_DATE, sizeof(descriptor.volumeModifyDate)) != 0)
 		{

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -915,8 +915,8 @@ void iso::DirTreeClass::WriteDescriptor(cd::IsoWriter* writer, const iso::IDENTI
 	CopyStringPadWithSpaces( isoDescriptor.copyrightFileIdentifier, id.Copyright );
 
 	// Unneeded identifiers
-	CopyStringPadWithSpaces( isoDescriptor.abstractFileIdentifier, nullptr );
-	CopyStringPadWithSpaces( isoDescriptor.bibliographicFilelIdentifier, nullptr );
+	CopyStringPadWithSpaces( isoDescriptor.abstractFileIdentifier, id.AbstractFile );
+	CopyStringPadWithSpaces( isoDescriptor.bibliographicFilelIdentifier, id.BibliographicFile );
 
 	ParseLongDateFromString( isoDescriptor.volumeCreateDate, id.CreationDate );
 	ParseLongDateFromString( isoDescriptor.volumeModifyDate, id.ModificationDate );

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -18,6 +18,8 @@ namespace iso
 		const char* Copyright;
 		const char* CreationDate;
 		const char* ModificationDate;
+		const char* AbstractFile;
+		const char* BibliographicFile;
 	} IDENTIFIERS;
 
 	struct DIRENTRY

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -1022,6 +1022,8 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 		isoIdentifiers.Copyright	= identifierElement->Attribute(xml::attrib::COPYRIGHT);
 		isoIdentifiers.CreationDate	= identifierElement->Attribute(xml::attrib::CREATION_DATE);
 		isoIdentifiers.ModificationDate = identifierElement->Attribute(xml::attrib::MODIFICATION_DATE);
+		isoIdentifiers.AbstractFile = identifierElement->Attribute(xml::attrib::ABSTRACT_FILE);
+		isoIdentifiers.BibliographicFile = identifierElement->Attribute(xml::attrib::BIBLIOGRAPHIC_FILE);
 
 		// Is an ID file specified?
 		if( const char* identifierFile = identifierElement->Attribute(xml::attrib::ID_FILE) )
@@ -1085,6 +1087,10 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 					isoIdentifiers.CreationDate		= str;
 				if( (str = identifierElement->Attribute(xml::attrib::MODIFICATION_DATE)) )
 					isoIdentifiers.ModificationDate = str;
+				if( (str = identifierElement->Attribute(xml::attrib::ABSTRACT_FILE)) )
+					isoIdentifiers.AbstractFile = str;
+				if( (str = identifierElement->Attribute(xml::attrib::BIBLIOGRAPHIC_FILE)) )
+					isoIdentifiers.BibliographicFile = str;
 			}
 		}
 	}
@@ -1261,7 +1267,12 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 		? (xmlPath / reinterpret_cast<const char8_t*>(dirTreePath)).lexically_normal()
 		: xmlPath;
 
-	iso::DIRENTRY& root = iso::DirTreeClass::CreateRootDirectory(entries, volumeDate, ReadEntryAttributes(defaultAttributes, directoryTree));
+	cd::ISO_DATESTAMP rootDate = volumeDate;
+	if (const char* rootDateStr = directoryTree->Attribute(xml::attrib::ENTRY_DATE))
+	{
+		ParseDateFromString(rootDate, rootDateStr, volumeDate.GMToffs);
+	}
+	iso::DIRENTRY& root = iso::DirTreeClass::CreateRootDirectory(entries, rootDate, ReadEntryAttributes(defaultAttributes, directoryTree));
 	iso::DirTreeClass* dirTree = root.subdir.get();
 
 	if ( !ParseDirectory(dirTree, directoryTree, xmlPath, defaultAttributes, currentPath) )

--- a/src/shared/xml.h
+++ b/src/shared/xml.h
@@ -58,6 +58,8 @@ namespace attrib
 	constexpr const char* COPYRIGHT = "copyright";
 	constexpr const char* CREATION_DATE = "creation_date";
 	constexpr const char* MODIFICATION_DATE = "modification_date";
+	constexpr const char* ABSTRACT_FILE = "abstract_file";
+	constexpr const char* BIBLIOGRAPHIC_FILE = "bibliographic_file";
 
 	constexpr const char* NUM_DUMMY_SECTORS = "sectors";
 	constexpr const char* ECC_ADDRESS = "ecc_addr"; // Simulates the real address ECC calculation bug, used for 1:1 rebuilds.


### PR DESCRIPTION
i've started working on decamp for Harvest Moon - Back to Nature (USA) (`SLUS_011.15`) and noticed that 
roundtripping the stock disc through `dumppsxiso` & `mkpsxiso` wasn't producing a byte-identical `.bin`. 

found these two issues:

1. the root directory entry's date wasn't saved to the xml — `dumpsxiso` wrote
   the volume creation date but not the actual root dir timestamp on
   `<directory_tree>`, so `mkpsxiso` used the wrong one on rebuild

2. the PVD has `abstractFileIdentifier` and `bibliographicFilelIdentifier`
   fields pointing to `ABSTRACT.TXT` and `BIBLIOGP.TXT` on the disc, but they
   were never written to the xml. `mkpsxiso` just blanked them with spaces